### PR TITLE
Rename 'encrypt' to 'hash' or 'password'

### DIFF
--- a/app/uk/gov/hmrc/testuser/services/PasswordService.scala
+++ b/app/uk/gov/hmrc/testuser/services/PasswordService.scala
@@ -21,14 +21,14 @@ import javax.inject.Inject
 import org.mindrot.jbcrypt.{BCrypt => BCryptUtils}
 import uk.gov.hmrc.testuser.config.AppContext
 
-trait EncryptionService {
+trait PasswordService {
   val logRounds: Int
 
-  def encrypt(password: String): String = BCryptUtils.hashpw(password, BCryptUtils.gensalt(logRounds))
+  def hash(password: String): String = BCryptUtils.hashpw(password, BCryptUtils.gensalt(logRounds))
 
-  def validate(password: String, encryptedPassword: String) = BCryptUtils.checkpw(password, encryptedPassword)
+  def validate(password: String, hashedPassword: String) = BCryptUtils.checkpw(password, hashedPassword)
 }
 
-class EncryptionServiceImpl @Inject()(appContext: AppContext) extends EncryptionService {
+class PasswordServiceImpl @Inject()(appContext: AppContext) extends PasswordService {
   override lazy val logRounds = appContext.passwordLogRounds
 }

--- a/app/uk/gov/hmrc/testuser/services/TestUserService.scala
+++ b/app/uk/gov/hmrc/testuser/services/TestUserService.scala
@@ -25,22 +25,22 @@ trait TestUserService {
 
   val generator: Generator
   val testUserRepository: TestUserRepository
-  val encryptionService: EncryptionService
+  val passwordService: PasswordService
 
   def createTestIndividual() = {
     val individual = generator.generateTestIndividual()
-    val encryptedPassword =  encryptionService.encrypt(individual.password)
-    testUserRepository.createUser(individual.copy(password = encryptedPassword)) map (_ => individual)
+    val hashedPassword =  passwordService.hash(individual.password)
+    testUserRepository.createUser(individual.copy(password = hashedPassword)) map (_ => individual)
   }
 
   def createTestOrganisation() = {
     val organisation = generator.generateTestOrganisation()
-    val encryptedPassword =  encryptionService.encrypt(organisation.password)
-    testUserRepository.createUser(organisation.copy(password = encryptedPassword)) map (_ => organisation)
+    val hashedPassword =  passwordService.hash(organisation.password)
+    testUserRepository.createUser(organisation.copy(password = hashedPassword)) map (_ => organisation)
   }
 }
 
-class TestUserServiceImpl @Inject()(override val encryptionService: EncryptionServiceImpl) extends TestUserService {
+class TestUserServiceImpl @Inject()(override val passwordService: PasswordServiceImpl) extends TestUserService {
   override val generator: Generator = Generator
   override val testUserRepository = TestUserRepository()
 }

--- a/test/it/uk/gov/hmrc/CreateTestUserSpec.scala
+++ b/test/it/uk/gov/hmrc/CreateTestUserSpec.scala
@@ -54,7 +54,7 @@ with GivenWhenThen with BeforeAndAfterEach with BeforeAndAfterAll {
       response.code shouldBe SC_CREATED
       val individualResponse = Json.parse(response.body).as[TestIndividualResponse]
 
-      And("The individual is stored in mongo with encrypted password")
+      And("The individual is stored in mongo with hashed password")
       val individual = result(mongoRepository.fetchByUsername(individualResponse.username), timeout).get.asInstanceOf[TestIndividual]
       TestIndividualResponse.from(individual.copy(password = individualResponse.password)) shouldBe individualResponse
       validatePassword(individualResponse.password, individual.password) shouldBe true
@@ -69,7 +69,7 @@ with GivenWhenThen with BeforeAndAfterEach with BeforeAndAfterAll {
       response.code shouldBe SC_CREATED
       val organisationResponse = Json.parse(response.body).as[TestOrganisationResponse]
 
-      And("The organisation is stored in mongo with encrypted password")
+      And("The organisation is stored in mongo with hashed password")
       val organisation = result(mongoRepository.fetchByUsername(organisationResponse.username), timeout).get.asInstanceOf[TestOrganisation]
       TestOrganisationResponse.from(organisation.copy(password = organisationResponse.password)) shouldBe organisationResponse
       validatePassword(organisationResponse.password, organisation.password) shouldBe true
@@ -101,7 +101,7 @@ with GivenWhenThen with BeforeAndAfterEach with BeforeAndAfterAll {
     server.stop()
   }
 
-  private def validatePassword(password: String, encryptedPassword: String) =  BCryptUtils.checkpw(password, encryptedPassword)
+  private def validatePassword(password: String, hashedPassword: String) =  BCryptUtils.checkpw(password, hashedPassword)
 
   def mongoRepository = {
     implicit val mongo = MongoConnector("mongodb://localhost:27017/api-platform-test-user-it").db

--- a/test/unit/uk/gov/hmrc/testuser/services/PasswordServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/testuser/services/PasswordServiceSpec.scala
@@ -17,39 +17,39 @@
 package unit.uk.gov.hmrc.testuser.services
 
 import uk.gov.hmrc.play.test.UnitSpec
-import uk.gov.hmrc.testuser.services.EncryptionService
+import uk.gov.hmrc.testuser.services.PasswordService
 
-class EncryptionServiceSpec extends UnitSpec{
+class PasswordServiceSpec extends UnitSpec{
 
   trait Setup {
-    val underTest = new EncryptionService {
+    val underTest = new PasswordService {
       override val logRounds: Int = 12
     }
   }
 
-  "encrypt" should {
-    "return the encrypted password" in new Setup {
+  "hash" should {
+    "return the hashed password" in new Setup {
 
-      val encryptedPassword = underTest.encrypt("aPassword")
+      val hashedPassword = underTest.hash("aPassword")
 
-      encryptedPassword should not be "aPassword"
-      underTest.validate("aPassword", encryptedPassword) shouldBe true
+      hashedPassword should not be "aPassword"
+      underTest.validate("aPassword", hashedPassword) shouldBe true
     }
   }
 
   "validate" should {
     "return true when the password is correct" in new Setup {
 
-      val encryptedPassword = underTest.encrypt("aPassword")
+      val hashedPassword = underTest.hash("aPassword")
 
-      underTest.validate("aPassword", encryptedPassword) shouldBe true
+      underTest.validate("aPassword", hashedPassword) shouldBe true
     }
 
     "return false when the password is incorrect" in new Setup {
 
-      val anotherEncryptedPassword = underTest.encrypt("anotherPassword")
+      val anotherHashedPassword = underTest.hash("anotherPassword")
 
-      underTest.validate("aPassword", anotherEncryptedPassword) shouldBe false
+      underTest.validate("aPassword", anotherHashedPassword) shouldBe false
     }
 
   }

--- a/test/unit/uk/gov/hmrc/testuser/services/TestUserServiceSpec.scala
+++ b/test/unit/uk/gov/hmrc/testuser/services/TestUserServiceSpec.scala
@@ -26,7 +26,7 @@ import uk.gov.hmrc.domain._
 import uk.gov.hmrc.play.test.UnitSpec
 import uk.gov.hmrc.testuser.models.{TestOrganisation, TestUser, TestIndividual}
 import uk.gov.hmrc.testuser.repository.TestUserRepository
-import uk.gov.hmrc.testuser.services.{EncryptionService, Generator, TestUserService}
+import uk.gov.hmrc.testuser.services.{PasswordService, Generator, TestUserService}
 import scala.concurrent.Future
 import scala.concurrent.Future.successful
 
@@ -40,23 +40,23 @@ class TestUserServiceSpec extends UnitSpec with MockitoSugar {
     val underTest = new TestUserService {
       override val generator: Generator = mock[Generator]
       override val testUserRepository: TestUserRepository = mock[TestUserRepository]
-      override val encryptionService: EncryptionService = mock[EncryptionService]
+      override val passwordService: PasswordService = mock[PasswordService]
     }
     when(underTest.testUserRepository.createUser(Matchers.any[TestUser]())).thenAnswer(sameUser)
   }
 
   "createTestIndividual" should {
 
-    "Generate an individual and save it with encrypted password in the database" in new Setup {
+    "Generate an individual and save it with hashed password in the database" in new Setup {
 
-      val encryptedPassword  = "encryptedPassword"
+      val hashedPassword  = "hashedPassword"
       given(underTest.generator.generateTestIndividual()).willReturn(testIndividual)
-      given(underTest.encryptionService.encrypt(testIndividual.password)).willReturn(encryptedPassword)
+      given(underTest.passwordService.hash(testIndividual.password)).willReturn(hashedPassword)
 
       val result = await(underTest.createTestIndividual())
 
       result shouldBe testIndividual
-      verify(underTest.testUserRepository).createUser(testIndividual.copy(password = encryptedPassword))
+      verify(underTest.testUserRepository).createUser(testIndividual.copy(password = hashedPassword))
     }
 
     "fail when the repository fails" in new Setup {
@@ -72,14 +72,14 @@ class TestUserServiceSpec extends UnitSpec with MockitoSugar {
 
     "Generate an organisation and save it in the database" in new Setup {
 
-      val encryptedPassword  = "encryptedPassword"
+      val hashedPassword  = "hashedPassword"
       given(underTest.generator.generateTestOrganisation()).willReturn(testOrganisation)
-      given(underTest.encryptionService.encrypt(testOrganisation.password)).willReturn(encryptedPassword)
+      given(underTest.passwordService.hash(testOrganisation.password)).willReturn(hashedPassword)
 
       val result = await(underTest.createTestOrganisation())
 
       result shouldBe testOrganisation
-      verify(underTest.testUserRepository).createUser(testOrganisation.copy(password = encryptedPassword))
+      verify(underTest.testUserRepository).createUser(testOrganisation.copy(password = hashedPassword))
     }
 
     "fail when the repository fails" in new Setup {


### PR DESCRIPTION
Strictly speaking, we're hashing the passwords - not encrypting them -
since it's an irreversable transformation.