### PR TITLE
Temporarily mark as private

### DIFF
--- a/resources/public/api/definition.json
+++ b/resources/public/api/definition.json
@@ -7,7 +7,14 @@
     "versions": [
       {
         "version": "1.0",
-        "status": "PUBLISHED"
+        "status": "PUBLISHED",
+        "access": {
+          "type": "PRIVATE",
+          "whitelistedApplicationIds": [
+            "ab349380-17cc-4de0-a7ac-c76baedd7133",
+            "943889f5-6bfb-4829-b3ef-18d7c2b65d5d"
+          ]
+        }
       }
     ]
   }


### PR DESCRIPTION
This is so the API can be tested in ETE in private. The change will
be reverted as soon as QA has completed successfully.