### PR TITLE
CDD-1159: allow user with Customs enrolment

### DIFF
--- a/app/uk/gov/hmrc/testuser/connectors/AuthLoginApiConnector.scala
+++ b/app/uk/gov/hmrc/testuser/connectors/AuthLoginApiConnector.scala
@@ -74,6 +74,7 @@ object GovernmentGatewayLogin {
       serviceName match {
         case SELF_ASSESSMENT => individual.saUtr map {saUtr => Enrolment("IR-SA", taxIdentifier(saUtr))}
         case MTD_INCOME_TAX => individual.mtdItId map {mtdItId => Enrolment("HMRC-MTD-IT", taxIdentifier(mtdItId))}
+        case CUSTOMS_SERVICES => individual.eoriNumber map { eoriNumber => Enrolment("HMRC-CUS-ORG", taxIdentifier(eoriNumber))}
         case _ => None
       }
     }
@@ -93,6 +94,7 @@ object GovernmentGatewayLogin {
         case LISA => organisation.lisaManRefNum map { lisaManRefNum => Enrolment("HMRC-LISA-ORG", taxIdentifier(lisaManRefNum))}
         case SECURE_ELECTRONIC_TRANSFER => organisation.secureElectronicTransferReferenceNumber map { setRefNum => Enrolment("HMRC-SET-ORG", taxIdentifier(setRefNum))}
         case RELIEF_AT_SOURCE => organisation.pensionSchemeAdministratorIdentifier map { psaId => Enrolment("HMRC-PSA-ORG", taxIdentifier(psaId))}
+        case CUSTOMS_SERVICES => organisation.eoriNumber map { eoriNumber => Enrolment("HMRC-CUS-ORG", taxIdentifier(eoriNumber))}
         case _ => None
       }
     }
@@ -126,6 +128,7 @@ object GovernmentGatewayLogin {
       case lisaManRefNum: LisaManagerReferenceNumber => Seq(Identifier("ZREF", lisaManRefNum.toString))
       case setRefNum: SecureElectronicTransferReferenceNumber => Seq(Identifier("SRN", setRefNum.toString))
       case psaId: PensionSchemeAdministratorIdentifier => Seq(Identifier("PSAID", psaId.toString))
+      case EoriNumber(value) => Seq(Identifier("EORINumber", value))
       case _ => Seq.empty
     }
   }

--- a/app/uk/gov/hmrc/testuser/models/TestUser.scala
+++ b/app/uk/gov/hmrc/testuser/models/TestUser.scala
@@ -21,7 +21,6 @@ import play.api.libs.json.{Format, Reads, Writes}
 import reactivemongo.bson.BSONObjectID
 import uk.gov.hmrc.domain._
 import uk.gov.hmrc.testuser.models.ServiceName.ServiceName
-import uk.gov.hmrc.testuser.models.UserType.UserType
 
 object ServiceName extends Enumeration {
   type ServiceName = Value
@@ -35,6 +34,7 @@ object ServiceName extends Enumeration {
   val LISA = Value("lisa")
   val SECURE_ELECTRONIC_TRANSFER = Value("secure-electronic-transfer")
   val RELIEF_AT_SOURCE = Value("relief-at-source")
+  val CUSTOMS_SERVICES = Value("customs-services")
 }
 
 sealed trait TestUser {
@@ -55,6 +55,7 @@ case class TestIndividual(override val userId: String,
                           saUtr: Option[SaUtr] = None,
                           nino: Option[Nino] = None,
                           mtdItId: Option[MtdItId] = None,
+                          eoriNumber: Option[EoriNumber] = None,
                           override val services: Seq[ServiceName] = Seq.empty,
                           override val _id: BSONObjectID = BSONObjectID.generate) extends TestUser {
   override val affinityGroup = "Individual"
@@ -74,6 +75,7 @@ case class TestOrganisation(override val userId: String,
                             lisaManRefNum: Option[LisaManagerReferenceNumber] = None,
                             secureElectronicTransferReferenceNumber: Option[SecureElectronicTransferReferenceNumber] = None,
                             pensionSchemeAdministratorIdentifier: Option[PensionSchemeAdministratorIdentifier] = None,
+                            eoriNumber: Option[EoriNumber] = None,
                             override val services: Seq[ServiceName] = Seq.empty,
                             override val _id: BSONObjectID = BSONObjectID.generate) extends TestUser {
   override val affinityGroup = "Organisation"
@@ -100,6 +102,7 @@ sealed trait TestIndividualResponse extends TestUserResponse {
   val saUtr: Option[SaUtr]
   val nino: Option[Nino]
   val mtdItId: Option[MtdItId]
+  val eoriNumber: Option[EoriNumber]
 }
 
 sealed trait TestOrganisationResponse extends TestUserResponse {
@@ -113,6 +116,7 @@ sealed trait TestOrganisationResponse extends TestUserResponse {
   val lisaManagerReferenceNumber: Option[LisaManagerReferenceNumber]
   val secureElectronicTransferReferenceNumber: Option[SecureElectronicTransferReferenceNumber]
   val pensionSchemeAdministratorIdentifier: Option[PensionSchemeAdministratorIdentifier]
+  val eoriNumber: Option[EoriNumber]
 }
 
 sealed trait TestAgentResponse extends TestUserResponse {
@@ -125,13 +129,14 @@ case class FetchTestIndividualResponse(override val userId: String,
                                        override val individualDetails: IndividualDetails,
                                        override val saUtr: Option[SaUtr] = None,
                                        override val nino: Option[Nino] = None,
-                                       override val mtdItId: Option[MtdItId] = None)
+                                       override val mtdItId: Option[MtdItId] = None,
+                                       override val eoriNumber: Option[EoriNumber] = None)
   extends TestIndividualResponse
 
 object FetchTestIndividualResponse {
   def from(individual: TestIndividual) = FetchTestIndividualResponse(individual.userId, individual.userFullName,
     individual.emailAddress, individual.individualDetails, individual.saUtr, individual.nino,
-    individual.mtdItId)
+    individual.mtdItId, individual.eoriNumber)
 }
 
 case class TestIndividualCreatedResponse(override val userId: String,
@@ -141,13 +146,14 @@ case class TestIndividualCreatedResponse(override val userId: String,
                                          override val individualDetails: IndividualDetails,
                                          override val saUtr: Option[SaUtr],
                                          override val nino: Option[Nino],
-                                         override val mtdItId: Option[MtdItId])
+                                         override val mtdItId: Option[MtdItId],
+                                         override val eoriNumber: Option[EoriNumber] = None)
   extends TestIndividualResponse
 
 object TestIndividualCreatedResponse {
   def from(individual: TestIndividual) = TestIndividualCreatedResponse(individual.userId, individual.password,
     individual.userFullName, individual.emailAddress, individual.individualDetails,
-    individual.saUtr, individual.nino, individual.mtdItId)
+    individual.saUtr, individual.nino, individual.mtdItId, individual.eoriNumber)
 }
 
 case class FetchTestOrganisationResponse(override val userId: String,
@@ -162,14 +168,16 @@ case class FetchTestOrganisationResponse(override val userId: String,
                                          override val vrn: Option[Vrn] = None,
                                          override val lisaManagerReferenceNumber: Option[LisaManagerReferenceNumber] = None,
                                          override val secureElectronicTransferReferenceNumber: Option[SecureElectronicTransferReferenceNumber] = None,
-                                         override val pensionSchemeAdministratorIdentifier: Option[PensionSchemeAdministratorIdentifier] = None)
+                                         override val pensionSchemeAdministratorIdentifier: Option[PensionSchemeAdministratorIdentifier] = None,
+                                         override val eoriNumber: Option[EoriNumber] = None)
   extends TestOrganisationResponse
 
 object FetchTestOrganisationResponse {
   def from(organisation: TestOrganisation) = FetchTestOrganisationResponse(organisation.userId, organisation.userFullName,
     organisation.emailAddress, organisation.organisationDetails, organisation.saUtr, organisation.nino,
     organisation.mtdItId, organisation.empRef, organisation.ctUtr, organisation.vrn, organisation.lisaManRefNum,
-    organisation.secureElectronicTransferReferenceNumber, organisation.pensionSchemeAdministratorIdentifier)
+    organisation.secureElectronicTransferReferenceNumber, organisation.pensionSchemeAdministratorIdentifier,
+    organisation.eoriNumber)
 }
 
 case class TestOrganisationCreatedResponse(override val userId: String,
@@ -185,7 +193,8 @@ case class TestOrganisationCreatedResponse(override val userId: String,
                                            override val vrn: Option[Vrn],
                                            override val lisaManagerReferenceNumber: Option[LisaManagerReferenceNumber],
                                            override val secureElectronicTransferReferenceNumber: Option[SecureElectronicTransferReferenceNumber],
-                                           override val pensionSchemeAdministratorIdentifier: Option[PensionSchemeAdministratorIdentifier])
+                                           override val pensionSchemeAdministratorIdentifier: Option[PensionSchemeAdministratorIdentifier],
+                                           override val eoriNumber: Option[EoriNumber] = None)
   extends TestOrganisationResponse
 
 object TestOrganisationCreatedResponse {
@@ -193,7 +202,7 @@ object TestOrganisationCreatedResponse {
     organisation.userFullName, organisation.emailAddress, organisation.organisationDetails, organisation.saUtr,
     organisation.nino, organisation.mtdItId, organisation.empRef, organisation.ctUtr, organisation.vrn,
     organisation.lisaManRefNum, organisation.secureElectronicTransferReferenceNumber,
-    organisation.pensionSchemeAdministratorIdentifier)
+    organisation.pensionSchemeAdministratorIdentifier, organisation.eoriNumber)
 }
 
 case class TestAgentCreatedResponse(override val userId: String, password: String,
@@ -229,8 +238,6 @@ case class MtdItId(mtdItId: String) extends TaxIdentifier with SimpleName {
   def value = mtdItId
 
   val name = "mtdItId"
-
-  def formatted = value
 }
 
 
@@ -286,9 +293,27 @@ object PensionSchemeAdministratorIdentifier extends (String => PensionSchemeAdmi
     new SimpleObjectReads[PensionSchemeAdministratorIdentifier]("pensionSchemeAdministratorIdentifier", PensionSchemeAdministratorIdentifier.apply)
 }
 
+case class EoriNumber(override val value: String) extends TaxIdentifier with SimpleName {
+  require(EoriNumber.isValid(value), s"$value is not a valid EORI.")
+
+  override val name = EoriNumber.name
+}
+
+object EoriNumber extends SimpleName {
+  val validEoriFormat = "^[A-z]{2}[0-9]{10,15}$"
+
+  def isValid(eoriNumber: String) = eoriNumber.matches(validEoriFormat)
+
+  override val name = "eoriNumber"
+
+  implicit val jsonFormat = Format[EoriNumber](
+    new SimpleObjectReads[EoriNumber](name, EoriNumber.apply),
+    new SimpleObjectWrites[EoriNumber](_.value)
+  )
+}
+
 case class Address(line1: String, line2: String, postcode: String)
 
 case class IndividualDetails(firstName: String, lastName: String, dateOfBirth: LocalDate, address: Address)
 
 case class OrganisationDetails(name: String, address: Address)
-

--- a/app/uk/gov/hmrc/testuser/services/Generator.scala
+++ b/app/uk/gov/hmrc/testuser/services/Generator.scala
@@ -43,16 +43,18 @@ trait Generator extends Randomiser {
   private val lisaManRefNumGenerator = new LisaGenerator()
   private val setRefNumGenerator = new SecureElectronicTransferReferenceNumberGenerator()
   private val psaIdGenerator = new PensionSchemeAdministratorIdentifierGenerator()
+  private val eoriGenerator = Gen.listOfN(10, Gen.numChar).map("GB" + _.mkString).map(EoriNumber.apply)
 
   def generateTestIndividual(services: Seq[ServiceName] = Seq.empty) = {
     val saUtr = if (services.contains(SELF_ASSESSMENT)) Some(generateSaUtr) else None
     val nino = if (services.contains(NATIONAL_INSURANCE) || services.contains(MTD_INCOME_TAX)) Some(generateNino) else None
     val mtdItId = if(services.contains(MTD_INCOME_TAX)) Some(generateMtdId) else None
+    val eoriNumber = if(services.contains(CUSTOMS_SERVICES)) Some(generateEoriNumber) else None
     val individualDetails = generateIndividualDetails
     val userFullName = generateUserFullName(individualDetails.firstName, individualDetails.lastName)
     val emailAddress = generateEmailAddress(individualDetails.firstName, individualDetails.lastName)
 
-    TestIndividual(generateUserId, generatePassword, userFullName, emailAddress, individualDetails, saUtr, nino, mtdItId, services)
+    TestIndividual(generateUserId, generatePassword, userFullName, emailAddress, individualDetails, saUtr, nino, mtdItId, eoriNumber, services)
   }
 
   def generateTestOrganisation(services: Seq[ServiceName] = Seq.empty) = {
@@ -65,6 +67,7 @@ trait Generator extends Randomiser {
     val lisaManRefNum = if (services.contains(LISA)) Some(generateLisaManRefNum) else None
     val setRefNum = if (services.contains(SECURE_ELECTRONIC_TRANSFER)) Some(generateSetRefNum) else None
     val psaId = if(services.contains(RELIEF_AT_SOURCE)) Some(generatePsaId) else None
+    val eoriNumber = if(services.contains(CUSTOMS_SERVICES)) Some(generateEoriNumber) else None
 
     val firstName = generateFirstName
     val lastName = generateLastName
@@ -72,7 +75,7 @@ trait Generator extends Randomiser {
     val emailAddress = generateEmailAddress(firstName, lastName)
 
     TestOrganisation(generateUserId, generatePassword, userFullName, emailAddress, generateOrganisationDetails, saUtr, nino, mtdItId, empRef, ctUtr,
-      vrn, lisaManRefNum, setRefNum, psaId, services)
+      vrn, lisaManRefNum, setRefNum, psaId, eoriNumber, services)
   }
 
   def generateTestAgent(services: Seq[ServiceName] = Seq.empty) = {
@@ -85,9 +88,9 @@ trait Generator extends Randomiser {
     TestAgent(generateUserId, generatePassword, userFullName, emailAddress, arn, services)
   }
 
-  def generateUserFullName(firstName: String, lastName: String) = s"${firstName} ${lastName}"
+  def generateUserFullName(firstName: String, lastName: String) = s"$firstName $lastName"
 
-  def generateEmailAddress(firstName: String, lastName: String) = s"${firstName}.${lastName}@example.com".toLowerCase
+  def generateEmailAddress(firstName: String, lastName: String) = s"$firstName.$lastName@example.com".toLowerCase
 
   def generateFirstName = randomConfigString("randomiser.individualDetails.firstName")
 
@@ -127,6 +130,7 @@ trait Generator extends Randomiser {
   private def generatePsaId: PensionSchemeAdministratorIdentifier = psaIdGenerator.next
   private def generateArn: AgentBusinessUtr = arnGenerator.next
   private def generateMtdId: MtdItId = mtdItIdGenerator.next
+  private def generateEoriNumber: EoriNumber = eoriGenerator.sample.get
 }
 
 object Generator extends Generator

--- a/resources/public/api/conf/1.0/examples/create-individual-request.json
+++ b/resources/public/api/conf/1.0/examples/create-individual-request.json
@@ -2,6 +2,7 @@
   "serviceNames": [
     "national-insurance",
     "self-assessment",
-    "mtd-income-tax"
+    "mtd-income-tax",
+    "customs-services"
   ]
 }

--- a/resources/public/api/conf/1.0/examples/create-individual-response.json
+++ b/resources/public/api/conf/1.0/examples/create-individual-response.json
@@ -15,5 +15,6 @@
   },
   "saUtr":"1000057161",
   "nino":"PE938808A",
-  "mtdItId":"XJIT00000328268"
+  "mtdItId":"XJIT00000328268",
+  "eoriNumber":"GB1234567890"
 }

--- a/resources/public/api/conf/1.0/examples/create-organisation-request.json
+++ b/resources/public/api/conf/1.0/examples/create-organisation-request.json
@@ -8,6 +8,7 @@
     "mtd-income-tax",
     "lisa",
     "secure-electronic-transfer",
-    "relief-at-source"
+    "relief-at-source",
+    "customs-services"
   ]
 }

--- a/resources/public/api/conf/1.0/examples/create-organisation-response.json
+++ b/resources/public/api/conf/1.0/examples/create-organisation-response.json
@@ -19,5 +19,6 @@
   "mtdItId":"XJIT00000328268",
   "lisaManagerReferenceNumber":"Z123456",
   "secureElectronicTransferReferenceNumber":"123456789012",
-  "pensionSchemeAdministratorIdentifier":"A1234567"
+  "pensionSchemeAdministratorIdentifier":"A1234567",
+  "eoriNumber":"GB1234567890"
 }

--- a/resources/public/api/conf/1.0/schemas/create-individual-request.json
+++ b/resources/public/api/conf/1.0/schemas/create-individual-request.json
@@ -12,7 +12,7 @@
         "oneOf": [
           {
             "enum": ["national-insurance"],
-            "description": "Generates a National Insurance number ane enrols the user for National Insurance"
+            "description": "Generates a National Insurance number and enrols the user for National Insurance"
           },
           {
             "enum": ["self-assessment"],
@@ -21,6 +21,10 @@
           {
             "enum": ["mtd-income-tax"],
             "description": "Generates a National Insurance number and a Making Tax Digital Income Tax ID and enrols the user for Making Tax Digital Income Tax"
+          },
+          {
+            "enum": ["customs-services"],
+            "description": "Generates an EORI number and enrols the user for Customs Services"
           }
         ]
       },

--- a/resources/public/api/conf/1.0/schemas/create-individual-response.json
+++ b/resources/public/api/conf/1.0/schemas/create-individual-response.json
@@ -76,6 +76,10 @@
     "mtdItId": {
       "type": "string",
       "description": "Making Tax Digital Income Tax ID"
+    },
+    "eoriNumber": {
+      "type": "string",
+      "description": "Economic Operator Registration and Identification (EORI) number"
     }
   },
   "required": [

--- a/resources/public/api/conf/1.0/schemas/create-organisation-request.json
+++ b/resources/public/api/conf/1.0/schemas/create-organisation-request.json
@@ -45,6 +45,10 @@
           {
             "enum": ["relief-at-source"],
             "description": "Generates a Pension Scheme Administrator Identifier and enrols the user for Relief at Source"
+          },
+          {
+            "enum": ["customs-services"],
+            "description": "Generates an EORI number and enrols the user for Customs Services"
           }
         ]
       },

--- a/resources/public/api/conf/1.0/schemas/create-organisation-response.json
+++ b/resources/public/api/conf/1.0/schemas/create-organisation-response.json
@@ -89,6 +89,10 @@
     "pensionSchemeAdministratorIdentifier": {
       "type": "string",
       "description": "Pension Scheme Administrator Identifier"
+    },
+    "eoriNumber": {
+      "type": "string",
+      "description": "Economic Operator Registration and Identification (EORI) number"
     }
   },
   "required": [

--- a/test/it/uk/gov/hmrc/testuser/connectors/AuthLoginApiConnectorSpec.scala
+++ b/test/it/uk/gov/hmrc/testuser/connectors/AuthLoginApiConnectorSpec.scala
@@ -35,14 +35,14 @@ class AuthLoginApiConnectorSpec extends UnitSpec with BeforeAndAfterEach with Wi
   val emailAddress = "john.doe@example.com"
 
   val testIndividual = TestIndividual("individualUser", "password", userFullName, emailAddress, individualDetails, Some(SaUtr("1555369052")), Some(Nino("CC333333C")),
-    Some(MtdItId("XGIT00000000054")), Seq(SELF_ASSESSMENT, NATIONAL_INSURANCE, MTD_INCOME_TAX))
+    Some(MtdItId("XGIT00000000054")), Some(EoriNumber("GB1234567890")), Seq(SELF_ASSESSMENT, NATIONAL_INSURANCE, MTD_INCOME_TAX, CUSTOMS_SERVICES))
 
   val testOrganisation = TestOrganisation("organisationUser", "password", userFullName, emailAddress,  organisationDetails, Some(SaUtr("1555369052")), Some(Nino("CC333333C")),
     Some(MtdItId("XGIT00000000054")), Some(EmpRef("555","EIA000")), Some(CtUtr("1555369053")), Some(Vrn("999902541")),
     Some(LisaManagerReferenceNumber("Z123456")), Some(SecureElectronicTransferReferenceNumber("123456789012")),
-    Some(PensionSchemeAdministratorIdentifier("A1234567")),
+    Some(PensionSchemeAdministratorIdentifier("A1234567")), Some(EoriNumber("GB1234567890")),
     Seq(SELF_ASSESSMENT, NATIONAL_INSURANCE, CORPORATION_TAX, SUBMIT_VAT_RETURNS, PAYE_FOR_EMPLOYERS, MTD_INCOME_TAX,
-      LISA, SECURE_ELECTRONIC_TRANSFER, RELIEF_AT_SOURCE))
+      LISA, SECURE_ELECTRONIC_TRANSFER, RELIEF_AT_SOURCE, CUSTOMS_SERVICES))
 
   val testAgent = TestAgent("agentUser", "password", userFullName, emailAddress, Some(AgentBusinessUtr("NARN0396245")), Seq(AGENT_SERVICES))
 
@@ -104,6 +104,15 @@ class AuthLoginApiConnectorSpec extends UnitSpec with BeforeAndAfterEach with Wi
           |       {
           |         "key":"MTDITID",
           |         "value":"${testIndividual.mtdItId.get.value}"
+          |       }]
+          |     },
+          |     {
+          |       "key": "HMRC-CUS-ORG",
+          |       "state": "Activated",
+          |       "identifiers": [
+          |       {
+          |         "key":"EORINumber",
+          |         "value":"${testIndividual.eoriNumber.get.value}"
           |       }]
           |     }
           |   ],
@@ -202,6 +211,15 @@ class AuthLoginApiConnectorSpec extends UnitSpec with BeforeAndAfterEach with Wi
            |       {
            |         "key":"PSAID",
            |         "value":"${testOrganisation.pensionSchemeAdministratorIdentifier.get.value}"
+           |       }]
+           |     },
+           |     {
+           |       "key": "HMRC-CUS-ORG",
+           |       "state": "Activated",
+           |       "identifiers": [
+           |       {
+           |         "key":"EORINumber",
+           |         "value":"${testOrganisation.eoriNumber.get.value}"
            |       }]
            |     }
            |   ],

--- a/test/unit/uk/gov/hmrc/testuser/controllers/AuthenticationControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/testuser/controllers/AuthenticationControllerSpec.scala
@@ -51,16 +51,18 @@ class AuthenticationControllerSpec extends UnitSpec with MockitoSugar with WithF
   val vrn = Vrn("999902541")
   val lisaManRefNum = LisaManagerReferenceNumber("Z123456")
   val empRef = EmpRef("555","EIA000")
+  val eoriNumber = EoriNumber("GB1234567890")
 
   val individualDetails = IndividualDetails("John", "Doe", LocalDate.parse("1980-01-10"), Address("221b Baker St", "Marylebone", "NW1 6XE"))
   val testIndividual = TestIndividual(user, password, userFullName, emailAddress, individualDetails,
-    Some(saUtr), Some(nino), Some(mtdItId),
-    Seq(SELF_ASSESSMENT, NATIONAL_INSURANCE, MTD_INCOME_TAX))
+    Some(saUtr), Some(nino), Some(mtdItId), Some(eoriNumber),
+    Seq(SELF_ASSESSMENT, NATIONAL_INSURANCE, MTD_INCOME_TAX, CUSTOMS_SERVICES))
 
   val organisationDetails = OrganisationDetails("Company ABCDEF",  Address("225 Baker St", "Marylebone", "NW1 6XE"))
   val testOrganisation = TestOrganisation(user, password, userFullName, emailAddress, organisationDetails,
     Some(saUtr), Some(nino), Some(mtdItId), Some(empRef), Some(ctUtr), Some(vrn), Some(lisaManRefNum),
-    services = Seq(SELF_ASSESSMENT, NATIONAL_INSURANCE, MTD_INCOME_TAX, PAYE_FOR_EMPLOYERS, CORPORATION_TAX, SUBMIT_VAT_RETURNS, LISA))
+    eoriNumber = Some(eoriNumber),
+    services = Seq(SELF_ASSESSMENT, NATIONAL_INSURANCE, MTD_INCOME_TAX, PAYE_FOR_EMPLOYERS, CORPORATION_TAX, SUBMIT_VAT_RETURNS, LISA, CUSTOMS_SERVICES))
 
   val authSession = AuthSession("Bearer AUTH_BEARER", "/auth/oid/12345", "gatewayToken")
 
@@ -106,7 +108,7 @@ class AuthenticationControllerSpec extends UnitSpec with MockitoSugar with WithF
       jsonBodyOf(result) shouldBe toJson(ErrorResponse.invalidCredentialsError)
     }
 
-    "fail with 500 (Internal Server Error) when an error occured " in new Setup {
+    "fail with 500 (Internal Server Error) when an error has occurred " in new Setup {
       withSuppressedLoggingFrom(Logger, "expected test error") { _ =>
         given(underTest.authenticationService.authenticate(refEq(AuthenticationRequest(user, password)))(any()))
           .willReturn(failed(new RuntimeException("expected test error")))

--- a/test/unit/uk/gov/hmrc/testuser/controllers/TestUserControllerSpec.scala
+++ b/test/unit/uk/gov/hmrc/testuser/controllers/TestUserControllerSpec.scala
@@ -54,17 +54,18 @@ class TestUserControllerSpec extends UnitSpec with MockitoSugar with WithFakeApp
   val lisaManagerReferenceNumber = LisaManagerReferenceNumber("Z123456")
   val secureElectronicTransferReferenceNumber = SecureElectronicTransferReferenceNumber("123456789012")
   val pensionSchemeAdministratorIdentifier = PensionSchemeAdministratorIdentifier("A1234567")
+  val eoriNumber = EoriNumber("GB1234567890")
 
   val individualDetails = IndividualDetails("John", "Doe", LocalDate.parse("1980-01-10"), Address("221b Baker St", "Marylebone", "NW1 6XE"))
   val organisationDetails = OrganisationDetails("Company ABCDEF",  Address("225 Baker St", "Marylebone", "NW1 6XE"))
 
   val testIndividual = TestIndividual(user, password, userFullName, emailAddress, individualDetails,
-    Some(saUtr), Some(nino), Some(mtdItId))
+    Some(saUtr), Some(nino), Some(mtdItId), Some(eoriNumber))
 
   val testOrganisation = TestOrganisation(user, password, userFullName, emailAddress, organisationDetails,
     Some(saUtr), Some(nino), Some(mtdItId),
     Some(empRef), Some(ctUtr), Some(vrn), Some(lisaManagerReferenceNumber), Some(secureElectronicTransferReferenceNumber),
-    Some(pensionSchemeAdministratorIdentifier))
+    Some(pensionSchemeAdministratorIdentifier), Some(eoriNumber))
 
   val testAgent = TestAgent(user, password, userFullName, emailAddress, Some(arn))
 
@@ -108,7 +109,7 @@ class TestUserControllerSpec extends UnitSpec with MockitoSugar with WithFakeApp
 
       status(result) shouldBe CREATED
       jsonBodyOf(result) shouldBe toJson(TestIndividualCreatedResponse(user, password, userFullName, emailAddress,
-        individualDetails, Some(saUtr), Some(nino), Some(mtdItId)))
+        individualDetails, Some(saUtr), Some(nino), Some(mtdItId), Some(eoriNumber)))
     }
 
     "fail with 500 (Internal Server Error) when the creation of the individual failed" in new Setup {
@@ -137,7 +138,7 @@ class TestUserControllerSpec extends UnitSpec with MockitoSugar with WithFakeApp
       jsonBodyOf(result) shouldBe toJson(TestOrganisationCreatedResponse(user, password, userFullName, emailAddress,
         organisationDetails, Some(saUtr),
         Some(nino), Some(mtdItId), Some(empRef), Some(ctUtr), Some(vrn), Some(lisaManagerReferenceNumber),
-        Some(secureElectronicTransferReferenceNumber), Some(pensionSchemeAdministratorIdentifier)))
+        Some(secureElectronicTransferReferenceNumber), Some(pensionSchemeAdministratorIdentifier), Some(eoriNumber)))
     }
 
     "fail with 500 (Internal Server Error) when the creation of the organisation failed" in new Setup {


### PR DESCRIPTION
- `HMRC-CUS-ORG` as GG service code name
- `Customs Services` as GG service "human readable" name as it appears (or will appear) on the GG list of services
- `EORINumber` as primary identifier code name
- `Economic Operator Registration and Identification (EORI) number` as primary identifier "human readable" name
- `ISO alpha 2 country code followed by 10 to 15 digits` as format of the primary identifier
- `customs-services` as new service's code name (solely a name to be used in the Create Test User API)
- `eoriNumber` as field name for primary identifier
- `Individuals` and `Organisations` as the user types applicable to new service