### PR TITLE
LISA-1711: Updated LISA ZREF generator

### DIFF
--- a/app/uk/gov/hmrc/testuser/services/Generator.scala
+++ b/app/uk/gov/hmrc/testuser/services/Generator.scala
@@ -158,7 +158,7 @@ class LisaGenerator(random: Random = new Random) extends Modulus23Check {
   def this(seed: Int) = this(new scala.util.Random(seed))
 
   def next: LisaManagerReferenceNumber = {
-    val randomCode = f"${random.nextInt(999999)}%06d"
+    val randomCode = if (random.nextBoolean()) f"${random.nextInt(999999)}%06d" else f"${random.nextInt(9999)}%04d"
     LisaManagerReferenceNumber(s"Z$randomCode")
   }
 }

--- a/resources/public/api/conf/1.0/schemas/create-organisation-response.json
+++ b/resources/public/api/conf/1.0/schemas/create-organisation-response.json
@@ -80,7 +80,7 @@
     },
     "lisaManagerReferenceNumber": {
       "type": "string",
-      "description": "LISA Manager Reference Number"
+      "description": "LISA Manager Reference Number, in either 4-digit format (Znnnn) or 6-digit format (Znnnnnn)"
     },
     "secureElectronicTransferReferenceNumber": {
       "type": "string",


### PR DESCRIPTION
LISA manager reference numbers are always a 'Z' followed by four OR six numbers. It's been requested we update the create test user API so that the reference numbers it generates can contain four or six numbers also, rather than always being set at six every time.