### PR TITLE
HODS-275 | Add additional param for taxpayer type

### DIFF
--- a/app/uk/gov/hmrc/testuser/controllers/TestUserController.scala
+++ b/app/uk/gov/hmrc/testuser/controllers/TestUserController.scala
@@ -35,7 +35,7 @@ class TestUserController @Inject()(val testUserService: TestUserService, cc: Con
   extends BackendController(cc) {
 
   def createIndividual() = Action.async(parse.json) { implicit request =>
-    withJsonBody[CreateUserWithOptionalEoriRequest] { createUserRequest =>
+    withJsonBody[CreateUserWithOptionalRequestParams] { createUserRequest =>
       testUserService.createTestIndividual(createUserRequest.serviceNames.getOrElse(Seq.empty), createUserRequest.eoriNumber) map { individual =>
         Created(toJson(TestIndividualCreatedResponse.from(individual)))
       }
@@ -43,8 +43,12 @@ class TestUserController @Inject()(val testUserService: TestUserService, cc: Con
   }
 
   def createOrganisation() = Action.async(parse.json) { implicit request =>
-    withJsonBody[CreateUserWithOptionalEoriRequest] { createUserRequest =>
-      testUserService.createTestOrganisation(createUserRequest.serviceNames.getOrElse(Seq.empty), createUserRequest.eoriNumber) map { organisation =>
+    withJsonBody[CreateUserWithOptionalRequestParams] { createUserRequest =>
+      testUserService.createTestOrganisation(
+        createUserRequest.serviceNames.getOrElse(Seq.empty),
+        createUserRequest.eoriNumber,
+        createUserRequest.taxpayerType
+      ) map { organisation =>
         Created(toJson(TestOrganisationCreatedResponse.from(organisation)))
       }
     } recover recovery

--- a/app/uk/gov/hmrc/testuser/models/JsonFormatters.scala
+++ b/app/uk/gov/hmrc/testuser/models/JsonFormatters.scala
@@ -54,7 +54,7 @@ object JsonFormatters {
   implicit val formatCreateUserServicesRequest = Json.format[CreateUserRequest]
 
   implicit val formatEoriNumber = Json.valueFormat[EoriNumber]
-  implicit val formatCreateUserWithOptionalEoriRequest = Json.format[CreateUserWithOptionalEoriRequest]
+  implicit val formatCreateUserWithOptionalEoriRequest = Json.format[CreateUserWithOptionalRequestParams]
 
   implicit val formatFetchTestIndividualResponse = Json.format[FetchTestIndividualResponse]
   implicit val formatFetchTestOrganisationResponse = Json.format[FetchTestOrganisationResponse]

--- a/app/uk/gov/hmrc/testuser/models/JsonFormatters.scala
+++ b/app/uk/gov/hmrc/testuser/models/JsonFormatters.scala
@@ -53,6 +53,7 @@ object JsonFormatters {
 
   implicit val formatCreateUserServicesRequest = Json.format[CreateUserRequest]
 
+  implicit val formatTaxpayerType = Json.valueFormat[TaxpayerType]
   implicit val formatEoriNumber = Json.valueFormat[EoriNumber]
   implicit val formatCreateUserWithOptionalEoriRequest = Json.format[CreateUserWithOptionalRequestParams]
 

--- a/app/uk/gov/hmrc/testuser/models/Payloads.scala
+++ b/app/uk/gov/hmrc/testuser/models/Payloads.scala
@@ -25,7 +25,7 @@ case class AuthenticationResponse(gatewayToken: String, affinityGroup: String)
 
 case class AuthSession(authBearerToken: String, authorityUri: String, gatewayToken: String)
 
-case class CreateUserWithOptionalEoriRequest(serviceNames: Option[Seq[ServiceKey]], eoriNumber: Option[EoriNumber])
+case class CreateUserWithOptionalRequestParams(serviceNames: Option[Seq[ServiceKey]], eoriNumber: Option[EoriNumber], taxpayerType: Option[String])
 
 case class CreateUserRequest(serviceNames: Option[Seq[ServiceKey]])
 

--- a/app/uk/gov/hmrc/testuser/models/Payloads.scala
+++ b/app/uk/gov/hmrc/testuser/models/Payloads.scala
@@ -25,7 +25,7 @@ case class AuthenticationResponse(gatewayToken: String, affinityGroup: String)
 
 case class AuthSession(authBearerToken: String, authorityUri: String, gatewayToken: String)
 
-case class CreateUserWithOptionalRequestParams(serviceNames: Option[Seq[ServiceKey]], eoriNumber: Option[EoriNumber], taxpayerType: Option[String])
+case class CreateUserWithOptionalRequestParams(serviceNames: Option[Seq[ServiceKey]], eoriNumber: Option[EoriNumber], taxpayerType: Option[TaxpayerType])
 
 case class CreateUserRequest(serviceNames: Option[Seq[ServiceKey]])
 

--- a/app/uk/gov/hmrc/testuser/models/TestUser.scala
+++ b/app/uk/gov/hmrc/testuser/models/TestUser.scala
@@ -380,7 +380,7 @@ case class TaxpayerType(override val value: String) extends SimpleName with TaxI
 }
 
 object TaxpayerType extends SimpleName {
-  def isValid(taxpayerType: String) = taxpayerType.toLowerCase == "individual" || taxpayerType.toLowerCase == "partnership"
+  def isValid(taxpayerType: String) = taxpayerType.trim.toLowerCase == "individual" || taxpayerType.trim.toLowerCase == "partnership"
   override val name = "taxpayerType"
 }
 

--- a/app/uk/gov/hmrc/testuser/models/TestUser.scala
+++ b/app/uk/gov/hmrc/testuser/models/TestUser.scala
@@ -237,7 +237,7 @@ object FetchTestOrganisationResponse {
     organisation.emailAddress, organisation.organisationDetails, organisation.saUtr, organisation.nino,
     organisation.mtdItId, organisation.empRef, organisation.ctUtr, organisation.vrn, organisation.vatRegistrationDate, organisation.lisaManRefNum,
     organisation.secureElectronicTransferReferenceNumber, organisation.pensionSchemeAdministratorIdentifier,
-    organisation.eoriNumber, organisation.groupIdentifier, organisation.crn)
+    organisation.eoriNumber, organisation.groupIdentifier, organisation.crn, organisation.taxpayerType)
 }
 
 case class TestOrganisationCreatedResponse(override val userId: String,
@@ -266,7 +266,8 @@ object TestOrganisationCreatedResponse {
     organisation.userFullName, organisation.emailAddress, organisation.organisationDetails, organisation.saUtr,
     organisation.nino, organisation.mtdItId, organisation.empRef, organisation.ctUtr, organisation.vrn, organisation.vatRegistrationDate,
     organisation.lisaManRefNum, organisation.secureElectronicTransferReferenceNumber,
-    organisation.pensionSchemeAdministratorIdentifier, organisation.eoriNumber, organisation.groupIdentifier, organisation.crn, organisation.taxpayerType)
+    organisation.pensionSchemeAdministratorIdentifier, organisation.eoriNumber, organisation.groupIdentifier,
+    organisation.crn, organisation.taxpayerType)
 }
 
 case class TestAgentCreatedResponse(override val userId: String, password: String,

--- a/app/uk/gov/hmrc/testuser/models/TestUser.scala
+++ b/app/uk/gov/hmrc/testuser/models/TestUser.scala
@@ -116,7 +116,8 @@ case class TestOrganisation(override val userId: String,
                             groupIdentifier: Option[String] = None,
                             override val services: Seq[ServiceKey] = Seq.empty,
                             override val _id: BSONObjectID = BSONObjectID.generate,
-                            crn: Option[String] = None) extends TestUser {
+                            crn: Option[String] = None,
+                            taxpayerType: Option[String] = None) extends TestUser {
   override val affinityGroup = "Organisation"
 }
 
@@ -163,6 +164,7 @@ sealed trait TestOrganisationResponse extends TestUserResponse {
   val eoriNumber: Option[String]
   val groupIdentifier: Option[String]
   val crn: Option[String]
+  val taxpayerType: Option[String]
 }
 
 sealed trait TestAgentResponse extends TestUserResponse {
@@ -226,7 +228,8 @@ case class FetchTestOrganisationResponse(override val userId: String,
                                          override val pensionSchemeAdministratorIdentifier: Option[String] = None,
                                          override val eoriNumber: Option[String] = None,
                                          override val groupIdentifier: Option[String] = None,
-                                         override val crn: Option[String] = None)
+                                         override val crn: Option[String] = None,
+                                         override val taxpayerType: Option[String] = None)
   extends TestOrganisationResponse
 
 object FetchTestOrganisationResponse {
@@ -254,7 +257,8 @@ case class TestOrganisationCreatedResponse(override val userId: String,
                                            override val pensionSchemeAdministratorIdentifier: Option[String],
                                            override val eoriNumber: Option[String] = None,
                                            override val groupIdentifier: Option[String] = None,
-                                           override val crn: Option[String] = None)
+                                           override val crn: Option[String] = None,
+                                           override val taxpayerType: Option[String] = None)
   extends TestOrganisationResponse
 
 object TestOrganisationCreatedResponse {
@@ -262,7 +266,7 @@ object TestOrganisationCreatedResponse {
     organisation.userFullName, organisation.emailAddress, organisation.organisationDetails, organisation.saUtr,
     organisation.nino, organisation.mtdItId, organisation.empRef, organisation.ctUtr, organisation.vrn, organisation.vatRegistrationDate,
     organisation.lisaManRefNum, organisation.secureElectronicTransferReferenceNumber,
-    organisation.pensionSchemeAdministratorIdentifier, organisation.eoriNumber, organisation.groupIdentifier, organisation.crn)
+    organisation.pensionSchemeAdministratorIdentifier, organisation.eoriNumber, organisation.groupIdentifier, organisation.crn, organisation.taxpayerType)
 }
 
 case class TestAgentCreatedResponse(override val userId: String, password: String,

--- a/app/uk/gov/hmrc/testuser/models/TestUser.scala
+++ b/app/uk/gov/hmrc/testuser/models/TestUser.scala
@@ -373,6 +373,17 @@ object EoriNumber extends SimpleName {
   override val name = "eoriNumber"
 }
 
+case class TaxpayerType(override val value: String) extends SimpleName with TaxIdentifier {
+  require(TaxpayerType.isValid(value), s"$value is not a valid Taxpayer Type.")
+
+  override val name = "taxpayerType"
+}
+
+object TaxpayerType extends SimpleName {
+  def isValid(taxpayerType: String) = taxpayerType.toLowerCase == "individual" || taxpayerType.toLowerCase == "partnership"
+  override val name = "taxpayerType"
+}
+
 case class Crn(override val value: String) extends TaxIdentifier with SimpleName {
   require(Crn.isValid(value), s"$value is not a valid CRN.")
   override val name: String = Crn.name

--- a/app/uk/gov/hmrc/testuser/services/Generator.scala
+++ b/app/uk/gov/hmrc/testuser/services/Generator.scala
@@ -102,7 +102,7 @@ class Generator @Inject()(val testUserRepository: TestUserRepository, val config
         services)
   }
 
-  def generateTestOrganisation(services: Seq[ServiceKey] = Seq.empty, eoriNumber: Option[EoriNumber], taxpayerType: Option[String] = None): Future[TestOrganisation] = {
+  def generateTestOrganisation(services: Seq[ServiceKey] = Seq.empty, eoriNumber: Option[EoriNumber], taxpayerType: Option[String]): Future[TestOrganisation] = {
     def whenF[T](keys: ServiceKey*)(thenDo: => Future[T]): Future[Option[T]] = Generator.whenF(services)(keys)(thenDo)
 
     def when[T](keys: ServiceKey*)(thenDo: => T): Option[T] = Generator.when(services)(keys)(thenDo)

--- a/app/uk/gov/hmrc/testuser/services/Generator.scala
+++ b/app/uk/gov/hmrc/testuser/services/Generator.scala
@@ -127,7 +127,7 @@ class Generator @Inject()(val testUserRepository: TestUserRepository, val config
       userFullName          = generateUserFullName(firstName, lastName)
       emailAddress          = generateEmailAddress(firstName, lastName)
       companyRegNo          <- whenF(CORPORATION_TAX)(generateCrn)
-      taxpayerType          <- whenF(SELF_ASSESSMENT)(useProvidedTaxpayerType(taxpayerType))
+      taxpayerType          <- whenF(SELF_ASSESSMENT)(useProvidedTaxpayerType(taxpayerType).map(maybeVal => maybeVal.trim))
     } yield
       TestOrganisation(
         generateUserId,

--- a/app/uk/gov/hmrc/testuser/services/Generator.scala
+++ b/app/uk/gov/hmrc/testuser/services/Generator.scala
@@ -67,9 +67,11 @@ class Generator @Inject()(val testUserRepository: TestUserRepository, val config
   private val arnGenerator = new ArnGenerator()
   private val crnGenerator = new CompanyReferenceNumberGenerator()
 
-  def useProvidedOrGenerateEoriNumber(eoriNumber: Option[EoriNumber]): Future[String] = eoriNumber.fold(generateEoriNumber)(provided => Future.successful(provided.value))
+  def useProvidedOrGenerateEoriNumber(eoriNumber: Option[EoriNumber]): Future[String] =
+    eoriNumber.fold(generateEoriNumber)(provided => Future.successful(provided.value))
 
-  def useProvidedTaxpayerType(maybeString: Option[String]): Future[Option[String]] = Future.successful(maybeString)
+  def useProvidedTaxpayerType(maybeString: Option[TaxpayerType]): Future[String] =
+    Future.successful(maybeString.fold("Individual")(provided => provided.value))
 
   def generateTestIndividual(services: Seq[ServiceKey] = Seq.empty, eoriNumber: Option[EoriNumber]): Future[TestIndividual] = {
     def whenF[T](keys: ServiceKey*)(thenDo: => Future[T]): Future[Option[T]] = Generator.whenF(services)(keys)(thenDo)
@@ -102,7 +104,7 @@ class Generator @Inject()(val testUserRepository: TestUserRepository, val config
         services)
   }
 
-  def generateTestOrganisation(services: Seq[ServiceKey] = Seq.empty, eoriNumber: Option[EoriNumber], taxpayerType: Option[String]): Future[TestOrganisation] = {
+  def generateTestOrganisation(services: Seq[ServiceKey] = Seq.empty, eoriNumber: Option[EoriNumber], taxpayerType: Option[TaxpayerType]): Future[TestOrganisation] = {
     def whenF[T](keys: ServiceKey*)(thenDo: => Future[T]): Future[Option[T]] = Generator.whenF(services)(keys)(thenDo)
 
     def when[T](keys: ServiceKey*)(thenDo: => T): Option[T] = Generator.when(services)(keys)(thenDo)
@@ -147,7 +149,7 @@ class Generator @Inject()(val testUserRepository: TestUserRepository, val config
         groupIdentifier,
         services,
         crn = companyRegNo,
-        taxpayerType = taxpayerType.getOrElse(None)
+        taxpayerType = taxpayerType
       )
   }
 
@@ -238,7 +240,7 @@ class Generator @Inject()(val testUserRepository: TestUserRepository, val config
   private def generateTaxPayerType(taxPayerType: String): Future[String] = {
     taxPayerType match {
       case "Individual" => Future.successful("Individual")
-      case "Partner" => Future.successful("Partner")
+      case "Partnership" => Future.successful("Partnership")
     }
   }
 }

--- a/app/uk/gov/hmrc/testuser/services/TestUserService.scala
+++ b/app/uk/gov/hmrc/testuser/services/TestUserService.scala
@@ -48,7 +48,7 @@ class TestUserService @Inject()(val passwordService: PasswordService,
     }
   }
 
-  def createTestOrganisation(serviceNames: Seq[ServiceKey], eoriNumber: Option[EoriNumber], taxpayerType: Option[String])
+  def createTestOrganisation(serviceNames: Seq[ServiceKey], eoriNumber: Option[EoriNumber], taxpayerType: Option[TaxpayerType])
                             (implicit hc: HeaderCarrier): Future[TestOrganisation] = {
     generator.generateTestOrganisation(serviceNames, eoriNumber, taxpayerType).flatMap { organisation =>
       val hashedPassword = passwordService.hash(organisation.password)

--- a/app/uk/gov/hmrc/testuser/services/TestUserService.scala
+++ b/app/uk/gov/hmrc/testuser/services/TestUserService.scala
@@ -48,7 +48,7 @@ class TestUserService @Inject()(val passwordService: PasswordService,
     }
   }
 
-  def createTestOrganisation(serviceNames: Seq[ServiceKey], eoriNumber: Option[EoriNumber], taxpayerType: Option[String] = None)
+  def createTestOrganisation(serviceNames: Seq[ServiceKey], eoriNumber: Option[EoriNumber], taxpayerType: Option[String])
                             (implicit hc: HeaderCarrier): Future[TestOrganisation] = {
     generator.generateTestOrganisation(serviceNames, eoriNumber, taxpayerType).flatMap { organisation =>
       val hashedPassword = passwordService.hash(organisation.password)

--- a/app/uk/gov/hmrc/testuser/services/TestUserService.scala
+++ b/app/uk/gov/hmrc/testuser/services/TestUserService.scala
@@ -34,7 +34,8 @@ class TestUserService @Inject()(val passwordService: PasswordService,
                                 val generator: Generator)
                                (implicit ec: ExecutionContext) {
 
-  def createTestIndividual(serviceNames: Seq[ServiceKey], eoriNumber: Option[EoriNumber] = None)(implicit hc: HeaderCarrier): Future[TestIndividual] = {
+  def createTestIndividual(serviceNames: Seq[ServiceKey], eoriNumber: Option[EoriNumber] = None)
+                          (implicit hc: HeaderCarrier): Future[TestIndividual] = {
     generator.generateTestIndividual(serviceNames, eoriNumber).flatMap { individual =>
       val hashedPassword = passwordService.hash(individual.password)
 
@@ -47,8 +48,9 @@ class TestUserService @Inject()(val passwordService: PasswordService,
     }
   }
 
-  def createTestOrganisation(serviceNames: Seq[ServiceKey], eoriNumber: Option[EoriNumber])(implicit hc: HeaderCarrier): Future[TestOrganisation] = {
-    generator.generateTestOrganisation(serviceNames, eoriNumber).flatMap { organisation =>
+  def createTestOrganisation(serviceNames: Seq[ServiceKey], eoriNumber: Option[EoriNumber], taxpayerType: Option[String] = None)
+                            (implicit hc: HeaderCarrier): Future[TestOrganisation] = {
+    generator.generateTestOrganisation(serviceNames, eoriNumber, taxpayerType).flatMap { organisation =>
       val hashedPassword = passwordService.hash(organisation.password)
       testUserRepository.createUser(organisation.copy(password = hashedPassword)) map {
         case createdOrganisation

--- a/it/uk/gov/hmrc/testuser/connectors/DesSimulatorConnectorSpec.scala
+++ b/it/uk/gov/hmrc/testuser/connectors/DesSimulatorConnectorSpec.scala
@@ -40,7 +40,7 @@ class DesSimulatorConnectorSpec extends AsyncHmrcSpec with GuiceOneAppPerSuite w
     when(repository.identifierIsUnique(any[String])).thenReturn(Future(true))
 
     val testIndividual = await(generator.generateTestIndividual(Seq(MTD_INCOME_TAX, SELF_ASSESSMENT, NATIONAL_INSURANCE), None))
-    val testOrganisation = await(generator.generateTestOrganisation(Seq(MTD_INCOME_TAX, SELF_ASSESSMENT, NATIONAL_INSURANCE, CORPORATION_TAX), None))
+    val testOrganisation = await(generator.generateTestOrganisation(Seq(MTD_INCOME_TAX, SELF_ASSESSMENT, NATIONAL_INSURANCE, CORPORATION_TAX), None, None))
 
     implicit val hc = HeaderCarrier()
 

--- a/it/uk/gov/hmrc/testuser/repository/TestUserRepositorySpec.scala
+++ b/it/uk/gov/hmrc/testuser/repository/TestUserRepositorySpec.scala
@@ -49,7 +49,7 @@ class TestUserRepositorySpec extends AsyncHmrcSpec with BeforeAndAfterEach with 
     val testOrganisation =
       await(
         generator.generateTestOrganisation(
-          Seq(MTD_INCOME_TAX, SELF_ASSESSMENT, NATIONAL_INSURANCE, CORPORATION_TAX, PAYE_FOR_EMPLOYERS, MTD_VAT, LISA, CUSTOMS_SERVICES, CTC), None))
+          Seq(MTD_INCOME_TAX, SELF_ASSESSMENT, NATIONAL_INSURANCE, CORPORATION_TAX, PAYE_FOR_EMPLOYERS, MTD_VAT, LISA, CUSTOMS_SERVICES, CTC), None, None))
   }
 
   override def afterEach: Unit = {

--- a/resources/public/api/conf/1.0/examples/create-organisation-request.json
+++ b/resources/public/api/conf/1.0/examples/create-organisation-request.json
@@ -15,5 +15,6 @@
     "safety-and-security",
     "common-transit-convention-traders"
   ],
-  "eoriNumber": "GB123456789012"
+  "eoriNumber": "GB123456789012",
+  "taxpayerType": "Individual"
 }

--- a/resources/public/api/conf/1.0/examples/create-organisation-response.json
+++ b/resources/public/api/conf/1.0/examples/create-organisation-response.json
@@ -21,5 +21,6 @@
   "lisaManagerReferenceNumber":"Z123456",
   "secureElectronicTransferReferenceNumber":"123456789012",
   "pensionSchemeAdministratorIdentifier":"A1234567",
-  "eoriNumber":"GB123456789012"
+  "eoriNumber":"GB123456789012",
+  "taxPayerType":"Individual"
 }

--- a/resources/public/api/conf/1.0/schemas/create-organisation-request.json
+++ b/resources/public/api/conf/1.0/schemas/create-organisation-request.json
@@ -76,6 +76,12 @@
       "minLength": 14,
       "maxLength": 17,
       "pattern": "^(GB|XI)[0-9]{12,15}$"
+    },
+    "taxPayerType": {
+      "type": "string",
+      "description": "Type of SA taxpayer Individual or Partner",
+      "minLength": 7,
+      "maxLength": 10
     }
   },
   "required": [

--- a/resources/public/api/conf/1.0/schemas/create-organisation-request.json
+++ b/resources/public/api/conf/1.0/schemas/create-organisation-request.json
@@ -79,7 +79,7 @@
     },
     "taxPayerType": {
       "type": "string",
-      "description": "Type of SA taxpayer Individual or Partner",
+      "description": "Type of SA taxpayer Individual or Partnership",
       "minLength": 7,
       "maxLength": 10
     }

--- a/resources/public/api/conf/1.0/schemas/create-organisation-request.json
+++ b/resources/public/api/conf/1.0/schemas/create-organisation-request.json
@@ -12,7 +12,7 @@
         "oneOf": [
           {
             "enum": ["corporation-tax"],
-            "description": "Generates a Corporation Tax UTR and enrols the user for Corporation Tax."
+            "description": "Generates a Corporation Tax Unique Taxpayer Reference (CTUTR), a Company Registration Number (CRN) and enrols the user for Corporation Tax."
           },
           {
             "enum": ["paye-for-employers"],

--- a/resources/public/api/conf/1.0/schemas/create-organisation-request.json
+++ b/resources/public/api/conf/1.0/schemas/create-organisation-request.json
@@ -79,9 +79,7 @@
     },
     "taxPayerType": {
       "type": "string",
-      "description": "Type of SA taxpayer Individual or Partnership",
-      "minLength": 7,
-      "maxLength": 10
+      "description": "Type of Self Assessment taxpayer One of 'Individual' or 'Partnership'"
     }
   },
   "required": [

--- a/resources/public/api/conf/1.0/schemas/create-organisation-response.json
+++ b/resources/public/api/conf/1.0/schemas/create-organisation-response.json
@@ -101,7 +101,7 @@
     },
     "taxPayerType": {
       "type": "string",
-      "description": "Type of SA taxpayer Individual or Partnership"
+      "description": "Type of Self Assessment taxpayer One of 'Individual' or 'Partnership'"
     }
   },
   "required": [

--- a/resources/public/api/conf/1.0/schemas/create-organisation-response.json
+++ b/resources/public/api/conf/1.0/schemas/create-organisation-response.json
@@ -101,7 +101,7 @@
     },
     "taxPayerType": {
       "type": "string",
-      "description": "Type of SA taxpayer Individual or Partner"
+      "description": "Type of SA taxpayer Individual or Partnership"
     }
   },
   "required": [

--- a/resources/public/api/conf/1.0/schemas/create-organisation-response.json
+++ b/resources/public/api/conf/1.0/schemas/create-organisation-response.json
@@ -101,7 +101,7 @@
     },
     "taxPayerType": {
       "type": "string",
-      "description": "Type of SA taxpayer Individual or Partner",
+      "description": "Type of SA taxpayer Individual or Partner"
     }
   },
   "required": [

--- a/resources/public/api/conf/1.0/schemas/create-organisation-response.json
+++ b/resources/public/api/conf/1.0/schemas/create-organisation-response.json
@@ -98,6 +98,10 @@
     "eoriNumber": {
       "type": "string",
       "description": "Economic Operator Registration and Identification (EORI) number."
+    },
+    "taxPayerType": {
+      "type": "string",
+      "description": "Type of SA taxpayer Individual or Partner",
     }
   },
   "required": [

--- a/test/uk/gov/hmrc/testuser/controllers/TestUserControllerSpec.scala
+++ b/test/uk/gov/hmrc/testuser/controllers/TestUserControllerSpec.scala
@@ -63,7 +63,7 @@ class TestUserControllerSpec extends AsyncHmrcSpec with LogSuppressing {
   val pensionSchemeAdministratorIdentifier = "A1234567"
   val rawEoriNumber = "GB123456789012"
   val eoriNumber = EoriNumber(rawEoriNumber)
-  val taxpayerType = "Individual"
+  val taxpayerType = TaxpayerType("Individual")
 
   val individualDetails = IndividualDetails("John", "Doe", LocalDate.parse("1980-01-10"), Address("221b Baker St", "Marylebone", "NW1 6XE"))
   val organisationDetails = OrganisationDetails("Company ABCDEF", Address("225 Baker St", "Marylebone", "NW1 6XE"))
@@ -225,7 +225,7 @@ class TestUserControllerSpec extends AsyncHmrcSpec with LogSuppressing {
       contentAsJson(result) shouldBe toJson(TestOrganisationCreatedResponse(user, password, userFullName, emailAddress,
         organisationDetails, Some(saUtr),
         Some(nino), Some(mtdItId), Some(empRef), Some(ctUtr), Some(vrn), Some(vatRegistrationDate), Some(lisaManagerReferenceNumber),
-        Some(secureElectronicTransferReferenceNumber), Some(pensionSchemeAdministratorIdentifier), Some(rawEoriNumber), Some(groupIdentifier), Some(crn), None))
+        Some(secureElectronicTransferReferenceNumber), Some(pensionSchemeAdministratorIdentifier), Some(rawEoriNumber), Some(groupIdentifier), Some(crn), Some("Individual")))
     }
 
     "return 201 (Created) with the created organisation with provided eori" in new Setup {

--- a/test/uk/gov/hmrc/testuser/controllers/TestUserControllerSpec.scala
+++ b/test/uk/gov/hmrc/testuser/controllers/TestUserControllerSpec.scala
@@ -64,6 +64,7 @@ class TestUserControllerSpec extends AsyncHmrcSpec with LogSuppressing {
   val rawEoriNumber = "GB123456789012"
   val eoriNumber = EoriNumber(rawEoriNumber)
   val taxpayerType = TaxpayerType("Individual")
+  val rawTaxpayerType = "Individual"
 
   val individualDetails = IndividualDetails("John", "Doe", LocalDate.parse("1980-01-10"), Address("221b Baker St", "Marylebone", "NW1 6XE"))
   val organisationDetails = OrganisationDetails("Company ABCDEF", Address("225 Baker St", "Marylebone", "NW1 6XE"))
@@ -146,7 +147,7 @@ class TestUserControllerSpec extends AsyncHmrcSpec with LogSuppressing {
 
     def createOrganisationWithProvidedEoriRequestTaxpayerType = {
       val jsonPayload: JsValue = Json.parse(
-        s"""{"serviceNames":["national-insurance"], "eoriNumber": "$rawEoriNumber", "taxpayerType": "$taxpayerType"}"""
+        s"""{"serviceNames":["national-insurance"], "eoriNumber": "$rawEoriNumber", "taxpayerType": "$rawTaxpayerType"}"""
       )
       FakeRequest().withBody[JsValue](jsonPayload)
     }
@@ -225,7 +226,7 @@ class TestUserControllerSpec extends AsyncHmrcSpec with LogSuppressing {
       contentAsJson(result) shouldBe toJson(TestOrganisationCreatedResponse(user, password, userFullName, emailAddress,
         organisationDetails, Some(saUtr),
         Some(nino), Some(mtdItId), Some(empRef), Some(ctUtr), Some(vrn), Some(vatRegistrationDate), Some(lisaManagerReferenceNumber),
-        Some(secureElectronicTransferReferenceNumber), Some(pensionSchemeAdministratorIdentifier), Some(rawEoriNumber), Some(groupIdentifier), Some(crn), Some("Individual")))
+        Some(secureElectronicTransferReferenceNumber), Some(pensionSchemeAdministratorIdentifier), Some(rawEoriNumber), Some(groupIdentifier), Some(crn), None))
     }
 
     "return 201 (Created) with the created organisation with provided eori" in new Setup {

--- a/test/uk/gov/hmrc/testuser/controllers/TestUserControllerSpec.scala
+++ b/test/uk/gov/hmrc/testuser/controllers/TestUserControllerSpec.scala
@@ -99,7 +99,8 @@ class TestUserControllerSpec extends AsyncHmrcSpec with LogSuppressing {
     pensionSchemeAdministratorIdentifier = Some(pensionSchemeAdministratorIdentifier),
     eoriNumber = Some(rawEoriNumber),
     groupIdentifier = Some(groupIdentifier),
-    crn = Some(crn))
+    crn = Some(crn),
+    taxpayerType = None)
 
   val testAgent = TestAgent(
     user,
@@ -206,7 +207,7 @@ class TestUserControllerSpec extends AsyncHmrcSpec with LogSuppressing {
 
     "return 201 (Created) with the created organisation" in new Setup {
 
-      when(underTest.testUserService.createTestOrganisation(eqTo(createOrganisationServices), eqTo(None))(any[HeaderCarrier])).thenReturn(successful(testOrganisation))
+      when(underTest.testUserService.createTestOrganisation(eqTo(createOrganisationServices), eqTo(None), eqTo(None))(any[HeaderCarrier])).thenReturn(successful(testOrganisation))
 
       val result = underTest.createOrganisation()(createOrganisationRequest)
 
@@ -214,12 +215,15 @@ class TestUserControllerSpec extends AsyncHmrcSpec with LogSuppressing {
       contentAsJson(result) shouldBe toJson(TestOrganisationCreatedResponse(user, password, userFullName, emailAddress,
         organisationDetails, Some(saUtr),
         Some(nino), Some(mtdItId), Some(empRef), Some(ctUtr), Some(vrn), Some(vatRegistrationDate), Some(lisaManagerReferenceNumber),
-        Some(secureElectronicTransferReferenceNumber), Some(pensionSchemeAdministratorIdentifier), Some(rawEoriNumber), Some(groupIdentifier), Some(crn)))
+        Some(secureElectronicTransferReferenceNumber), Some(pensionSchemeAdministratorIdentifier), Some(rawEoriNumber), Some(groupIdentifier), Some(crn), None))
     }
 
     "return 201 (Created) with the created organisation with provided eori" in new Setup {
 
-      when(underTest.testUserService.createTestOrganisation(eqTo(createOrganisationServices), eqTo(Some(eoriNumber)))(any[HeaderCarrier])).thenReturn(successful(testOrganisation))
+      when(underTest.testUserService.createTestOrganisation(
+        eqTo(createOrganisationServices),
+        eqTo(Some(eoriNumber)),
+        eqTo(None))(any[HeaderCarrier])).thenReturn(successful(testOrganisation))
 
       val result = underTest.createOrganisation()(createOrganisationWithProvidedEoriRequest)
 
@@ -228,7 +232,7 @@ class TestUserControllerSpec extends AsyncHmrcSpec with LogSuppressing {
 
     "fail with 500 (Internal Server Error) when the creation of the organisation failed" in new Setup {
       withSuppressedLoggingFrom(Logger, "expected test error") { _ =>
-        when(underTest.testUserService.createTestOrganisation(any[Seq[ServiceKey]], any[Option[EoriNumber]])(any[HeaderCarrier]))
+        when(underTest.testUserService.createTestOrganisation(any[Seq[ServiceKey]], any[Option[EoriNumber]], eqTo(None))(any[HeaderCarrier]))
           .thenReturn(failed(new RuntimeException("expected test error")))
 
         val result = underTest.createOrganisation()(createOrganisationRequest)

--- a/test/uk/gov/hmrc/testuser/services/GeneratorSpec.scala
+++ b/test/uk/gov/hmrc/testuser/services/GeneratorSpec.scala
@@ -333,12 +333,12 @@ class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {
       org shouldHave(ctUtrDefined = true, crnDefined = true)
     }
 
-    "generate a SA UTR when SELF_ASSESSMENT service is included" in new Setup {
+    "generate a SA UTR when SELF_ASSESSMENT service is included and taxpayerType defaults" in new Setup {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(true))
 
       val org = await(underTest.generateTestOrganisation(Seq(SELF_ASSESSMENT), None, None))
 
-      org shouldHave(saUtrDefined = true)
+      org shouldHave(saUtrDefined = true, taxpayerTypeDefined = true)
     }
 
     "generate a SA UTR and Individual Taxpayer when SELF_ASSESSMENT and taxpayerType is provided" in new Setup {

--- a/test/uk/gov/hmrc/testuser/services/GeneratorSpec.scala
+++ b/test/uk/gov/hmrc/testuser/services/GeneratorSpec.scala
@@ -344,15 +344,15 @@ class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {
     "generate a SA UTR and Individual Taxpayer when SELF_ASSESSMENT and taxpayerType is provided" in new Setup {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(true))
 
-      val org = await(underTest.generateTestOrganisation(Seq(SELF_ASSESSMENT), None, Some("Individual")))
+      val org = await(underTest.generateTestOrganisation(Seq(SELF_ASSESSMENT), None, Some(TaxpayerType("Individual"))))
 
       org shouldHave(saUtrDefined = true, taxpayerTypeDefined = true)
     }
 
-    "generate a SA UTR and Partner Taxpayer when SELF_ASSESSMENT and taxpayerType is provided" in new Setup {
+    "generate a SA UTR and Partnership Taxpayer when SELF_ASSESSMENT and taxpayerType is provided" in new Setup {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(true))
 
-      val org = await(underTest.generateTestOrganisation(Seq(SELF_ASSESSMENT), None, Some("Partner")))
+      val org = await(underTest.generateTestOrganisation(Seq(SELF_ASSESSMENT), None, Some(TaxpayerType("Partnership"))))
 
       org shouldHave(saUtrDefined = true, taxpayerTypeDefined = true)
     }

--- a/test/uk/gov/hmrc/testuser/services/GeneratorSpec.scala
+++ b/test/uk/gov/hmrc/testuser/services/GeneratorSpec.scala
@@ -304,7 +304,7 @@ class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {
     "generate a NINO and MTD IT ID when MTD_INCOME_TAX service is included" in new Setup {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(true))
 
-      val org = await(underTest.generateTestOrganisation(Seq(MTD_INCOME_TAX), None))
+      val org = await(underTest.generateTestOrganisation(Seq(MTD_INCOME_TAX), None, None))
 
       org shouldHave(mtdItIdDefined = true, ninoDefined = true)
     }
@@ -312,7 +312,7 @@ class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {
     "generate a NINO when NATIONAL_INSURANCE service is included" in new Setup {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(true))
 
-      val org = await(underTest.generateTestOrganisation(Seq(NATIONAL_INSURANCE), None))
+      val org = await(underTest.generateTestOrganisation(Seq(NATIONAL_INSURANCE), None, None))
 
       org shouldHave(ninoDefined = true)
     }
@@ -320,7 +320,7 @@ class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {
     "generate a EMPREF when PAYE_FOR_EMPLOYERS service is included" in new Setup {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(true))
 
-      val org = await(underTest.generateTestOrganisation(Seq(PAYE_FOR_EMPLOYERS), None))
+      val org = await(underTest.generateTestOrganisation(Seq(PAYE_FOR_EMPLOYERS), None, None))
 
       org shouldHave(empRefDefined = true)
     }
@@ -328,7 +328,7 @@ class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {
     "generate a CT UTR and CRN when CORPORATION_TAX service is included" in new Setup {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(true))
 
-      val org = await(underTest.generateTestOrganisation(Seq(CORPORATION_TAX), None))
+      val org = await(underTest.generateTestOrganisation(Seq(CORPORATION_TAX), None, None))
 
       org shouldHave(ctUtrDefined = true, crnDefined = true)
     }
@@ -336,7 +336,7 @@ class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {
     "generate a SA UTR when SELF_ASSESSMENT service is included" in new Setup {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(true))
 
-      val org = await(underTest.generateTestOrganisation(Seq(SELF_ASSESSMENT), None))
+      val org = await(underTest.generateTestOrganisation(Seq(SELF_ASSESSMENT), None, None))
 
       org shouldHave(saUtrDefined = true)
     }
@@ -360,7 +360,7 @@ class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {
     "generate a VRN when SUBMIT_VAT_RETURNS service is included" in new Setup {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(true))
 
-      val org = await(underTest.generateTestOrganisation(Seq(SUBMIT_VAT_RETURNS), None))
+      val org = await(underTest.generateTestOrganisation(Seq(SUBMIT_VAT_RETURNS), None, None))
 
       org shouldHave(vrnDefined = true)
     }
@@ -368,7 +368,7 @@ class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {
     "generate a VRN when MTD_VAT service is included" in new Setup {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(true))
 
-      val org = await(underTest.generateTestOrganisation(Seq(MTD_VAT), None))
+      val org = await(underTest.generateTestOrganisation(Seq(MTD_VAT), None, None))
 
       org shouldHave(vrnDefined = true)
     }
@@ -376,7 +376,7 @@ class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {
     "generate a lisaManagerReferenceNumber when LISA service is included" in new Setup {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(true))
 
-      val org = await(underTest.generateTestOrganisation(Seq(LISA), None))
+      val org = await(underTest.generateTestOrganisation(Seq(LISA), None, None))
 
       org shouldHave(lisaManRefNumDefined = true)
     }
@@ -384,7 +384,7 @@ class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {
     "generate a secureElectronicTransferReferenceNumber when SECURE_ELECTRONIC_TRANSFER service is included" in new Setup {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(true))
 
-      val org = await(underTest.generateTestOrganisation(Seq(SECURE_ELECTRONIC_TRANSFER), None))
+      val org = await(underTest.generateTestOrganisation(Seq(SECURE_ELECTRONIC_TRANSFER), None, None))
 
       org shouldHave(secureElectronicTransferReferenceNumberDefined = true)
     }
@@ -392,7 +392,7 @@ class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {
     "generate a pensionSchemeAdministratorIdentifier when RELIEF_AT_SOURCE service is included" in new Setup {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(true))
 
-      val org = await(underTest.generateTestOrganisation(Seq(RELIEF_AT_SOURCE), None))
+      val org = await(underTest.generateTestOrganisation(Seq(RELIEF_AT_SOURCE), None, None))
 
       org shouldHave(pensionSchemeAdministratorIdentifierDefined = true)
     }
@@ -400,7 +400,7 @@ class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {
     "generate an EORI when CUSTOMS_SERVICES service is included" in new Setup {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(true))
 
-      val org = await(underTest.generateTestOrganisation(Seq(CUSTOMS_SERVICES), None))
+      val org = await(underTest.generateTestOrganisation(Seq(CUSTOMS_SERVICES), None, None))
 
       org shouldHave(eoriDefined = true)
     }
@@ -409,7 +409,7 @@ class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(true))
       val eori = eoriGenerator.sample.get
 
-      val org = await(underTest.generateTestOrganisation(Seq(CUSTOMS_SERVICES), Some(eori)))
+      val org = await(underTest.generateTestOrganisation(Seq(CUSTOMS_SERVICES), Some(eori), None))
 
       org shouldHave(eoriDefined = true)
       org.eoriNumber shouldBe Some(eori.value)
@@ -418,7 +418,7 @@ class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {
     "generate an EORI when CTC service is included" in new Setup {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(true))
 
-      val org = await(underTest.generateTestOrganisation(Seq(CTC), None))
+      val org = await(underTest.generateTestOrganisation(Seq(CTC), None, None))
 
       org shouldHave(eoriDefined = true)
     }
@@ -427,7 +427,7 @@ class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(true))
       val eori = eoriGenerator.sample.get
 
-      val org = await(underTest.generateTestOrganisation(Seq(CTC), Some(eori)))
+      val org = await(underTest.generateTestOrganisation(Seq(CTC), Some(eori), None))
 
       org shouldHave(eoriDefined = true)
       org.eoriNumber shouldBe Some(eori.value)
@@ -436,7 +436,7 @@ class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {
     "generate an EORI when GOODS_VEHICLE_MOVEMENTS service is included" in new Setup {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(true))
 
-      val org = await(underTest.generateTestOrganisation(Seq(GOODS_VEHICLE_MOVEMENTS), None))
+      val org = await(underTest.generateTestOrganisation(Seq(GOODS_VEHICLE_MOVEMENTS), None, None))
 
       org shouldHave (eoriDefined = true)
     }
@@ -445,7 +445,7 @@ class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(true))
       val eori = eoriGenerator.sample.get
 
-      val org = await(underTest.generateTestOrganisation(Seq(GOODS_VEHICLE_MOVEMENTS), Some(eori)))
+      val org = await(underTest.generateTestOrganisation(Seq(GOODS_VEHICLE_MOVEMENTS), Some(eori), None))
 
       org shouldHave (eoriDefined = true)
       org.eoriNumber shouldBe Some(eori.value)
@@ -454,7 +454,7 @@ class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {
     "generate an EORI when SAFETY_AND_SECURITY service is included" in new Setup {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(true))
 
-      val org = await(underTest.generateTestOrganisation(Seq(SAFETY_AND_SECURITY), None))
+      val org = await(underTest.generateTestOrganisation(Seq(SAFETY_AND_SECURITY), None, None))
 
       org shouldHave(eoriDefined = true)
     }
@@ -463,7 +463,7 @@ class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(true))
       val eori = eoriGenerator.sample.get
 
-      val org = await(underTest.generateTestOrganisation(Seq(SAFETY_AND_SECURITY), Some(eori)))
+      val org = await(underTest.generateTestOrganisation(Seq(SAFETY_AND_SECURITY), Some(eori), None))
 
       org shouldHave (eoriDefined = true)
       org.eoriNumber shouldBe Some(eori.value)
@@ -473,7 +473,7 @@ class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(true))
       val eoriToIgnore = eoriGenerator.sample.get
 
-      val org = await(underTest.generateTestOrganisation(Seq.empty, Some(eoriToIgnore)))
+      val org = await(underTest.generateTestOrganisation(Seq.empty, Some(eoriToIgnore), None))
 
       org shouldHave (eoriDefined = false)
     }
@@ -481,7 +481,7 @@ class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {
     "set the userFullName and emailAddress" in new Setup {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(true))
 
-      val organisation = await(underTest.generateTestOrganisation(Seq(MTD_INCOME_TAX), None))
+      val organisation = await(underTest.generateTestOrganisation(Seq(MTD_INCOME_TAX), None, None))
 
       organisation.userFullName.matches("[a-zA-Z]+ [a-zA-Z]+") shouldBe true
 
@@ -493,7 +493,7 @@ class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {
     "regenerate VRN if it is a duplicate" in new Setup {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(false), Future(true))
 
-      val organisation = await(underTest.generateTestOrganisation(Seq(SUBMIT_VAT_RETURNS), None))
+      val organisation = await(underTest.generateTestOrganisation(Seq(SUBMIT_VAT_RETURNS), None, None))
 
       organisation shouldHave(vrnDefined = true)
       verify(repository, times(2)).identifierIsUnique(any[String])
@@ -502,7 +502,7 @@ class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {
     "regenerate Employer Reference if it is a duplicate" in new Setup {
       when(repository.identifierIsUnique(any[String])).thenReturn(Future(false), Future(true))
 
-      val organisation = await(underTest.generateTestOrganisation(Seq(PAYE_FOR_EMPLOYERS), None))
+      val organisation = await(underTest.generateTestOrganisation(Seq(PAYE_FOR_EMPLOYERS), None, None))
 
       organisation shouldHave(empRefDefined = true)
       verify(repository, times(2)).identifierIsUnique(any[String])

--- a/test/uk/gov/hmrc/testuser/services/TestUserServiceSpec.scala
+++ b/test/uk/gov/hmrc/testuser/services/TestUserServiceSpec.scala
@@ -92,7 +92,7 @@ class TestUserServiceSpec extends AsyncHmrcSpec with LogSuppressing {
   val testIndividual = testIndividualWithNoServices.copy(services = individualServices)
 
   val organisationServices = Seq(ServiceKeys.NATIONAL_INSURANCE, ServiceKeys.MTD_INCOME_TAX)
-  val testOrganisationWithNoServices = await(generator.generateTestOrganisation(Seq.empty, None).map(
+  val testOrganisationWithNoServices = await(generator.generateTestOrganisation(Seq.empty, None, None).map(
     _.copy(
       userId = userId,
       password = password,
@@ -169,10 +169,10 @@ class TestUserServiceSpec extends AsyncHmrcSpec with LogSuppressing {
     "Generate an organisation and save it in the database" in new Setup {
 
       val hashedPassword = "hashedPassword"
-      when(underTest.generator.generateTestOrganisation(organisationServices, None)).thenReturn(successful(testOrganisation))
+      when(underTest.generator.generateTestOrganisation(organisationServices, None, None)).thenReturn(successful(testOrganisation))
       when(underTest.passwordService.hash(testOrganisation.password)).thenReturn(hashedPassword)
 
-      val result = await(underTest.createTestOrganisation(organisationServices, None))
+      val result = await(underTest.createTestOrganisation(organisationServices, None, None))
 
       result shouldBe testOrganisation
 
@@ -184,10 +184,10 @@ class TestUserServiceSpec extends AsyncHmrcSpec with LogSuppressing {
     "Not call the DES simulator when the organisation does not have the mtd-income-tax service" in new Setup {
 
       val hashedPassword = "hashedPassword"
-      when(underTest.generator.generateTestOrganisation(Seq.empty, None)).thenReturn(successful(testOrganisationWithNoServices))
+      when(underTest.generator.generateTestOrganisation(Seq.empty, None, None)).thenReturn(successful(testOrganisationWithNoServices))
       when(underTest.passwordService.hash(testOrganisationWithNoServices.password)).thenReturn(hashedPassword)
 
-      val result = await(underTest.createTestOrganisation(Seq.empty, None))
+      val result = await(underTest.createTestOrganisation(Seq.empty, None, None))
 
       result shouldBe testOrganisationWithNoServices
 
@@ -198,12 +198,12 @@ class TestUserServiceSpec extends AsyncHmrcSpec with LogSuppressing {
 
     "fail when the repository fails" in new Setup {
       withSuppressedLoggingFrom(Logger, "expected test error") { suppressedLogs =>
-        when(underTest.generator.generateTestOrganisation(organisationServices, None)).thenReturn(successful(testOrganisation))
+        when(underTest.generator.generateTestOrganisation(organisationServices, None, None)).thenReturn(successful(testOrganisation))
         when(underTest.testUserRepository.createUser(*[TestUser]))
           .thenReturn(failed(new RuntimeException("expected test error")))
 
         intercept[RuntimeException] {
-          await(underTest.createTestOrganisation(organisationServices, None))
+          await(underTest.createTestOrganisation(organisationServices, None, None))
         }
       }
     }


### PR DESCRIPTION

For 

https://jira.tools.tax.service.gov.uk/browse/HODS-275

Add taxpayer type data item when creating an organisation. 

**POST**

![Screenshot 2021-06-28 at 11 10 37](https://user-images.githubusercontent.com/40767309/123619872-843ba380-d801-11eb-99b2-29485bc942b5.png)

![Screenshot 2021-06-28 at 11 03 35](https://user-images.githubusercontent.com/40767309/123619560-345cdc80-d801-11eb-8bee-9e6e8ddbca25.png)

**GET**

![Screenshot 2021-06-28 at 11 04 09](https://user-images.githubusercontent.com/40767309/123619548-30c95580-d801-11eb-88f1-f20aa168305d.png)
![Screenshot 2021-06-28 at 11 03 59](https://user-images.githubusercontent.com/40767309/123619552-32931900-d801-11eb-8578-3405bba8f6c4.png)
![Screenshot 2021-06-28 at 11 03 50](https://user-images.githubusercontent.com/40767309/123619556-33c44600-d801-11eb-9548-e1e96887ccfd.png)

