### PR TITLE
APSR-1350 - Add ITMP data to auth session

### DIFF
--- a/app/uk/gov/hmrc/testuser/models/JsonFormatters.scala
+++ b/app/uk/gov/hmrc/testuser/models/JsonFormatters.scala
@@ -20,8 +20,7 @@ import org.joda.time.LocalDate
 import play.api.libs.json._
 import uk.gov.hmrc.mongo.json.ReactiveMongoFormats
 import uk.gov.hmrc.play.json.Union
-import uk.gov.hmrc.testuser.connectors.{Enrolment, GovernmentGatewayLogin, Identifier}
-
+import uk.gov.hmrc.testuser.connectors.{Enrolment, GovernmentGatewayLogin, Identifier, ItmpData, AuthLoginAddress}
 object JsonFormatters {
 
   implicit val formatLocalDateWriter: Writes[LocalDate] = JodaWrites.jodaLocalDateWrites("yyyy-MM-dd")
@@ -65,6 +64,9 @@ object JsonFormatters {
 
   implicit val formatTaxIdentifier = Json.format[Identifier]
   implicit val formatEnrolment = Json.format[Enrolment]
+
+  implicit val formatAuthLoginAddress = Json.format[AuthLoginAddress]
+  implicit val formatItmpData = Json.format[ItmpData]
   implicit val formatGovernmentGatewayLogin = Json.format[GovernmentGatewayLogin]
 
   implicit val formatDesSimulatorTestIndividual = Json.format[DesSimulatorTestIndividual]

--- a/app/uk/gov/hmrc/testuser/services/AuthenticationService.scala
+++ b/app/uk/gov/hmrc/testuser/services/AuthenticationService.scala
@@ -44,9 +44,9 @@ class AuthenticationService @Inject()(val passwordService: PasswordService,
       }
     }
     for {
-      user <- userFuture
-      authSession <- authLoginApiConnector.createSession(user)
-    } yield (user, authSession)
+      testUser <- userFuture
+      authSession <- authLoginApiConnector.createSession(testUser)
+    } yield (testUser, authSession)
   }
 
   def authenticateByCredId(credId: String)(implicit hc: HeaderCarrier): Future[(TestUser, AuthSession)] = {

--- a/it/uk/gov/hmrc/testuser/connectors/AuthLoginApiConnectorSpec.scala
+++ b/it/uk/gov/hmrc/testuser/connectors/AuthLoginApiConnectorSpec.scala
@@ -197,7 +197,22 @@ class AuthLoginApiConnectorSpec extends AsyncHmrcSpec with GuiceOneAppPerSuite w
              |     }
              |   ],
              |   "usersName": "John Doe",
-             |   "email": "john.doe@example.com"
+             |   "email": "john.doe@example.com",
+             |   "itmpData" : {
+             |     "givenName" : "John",
+             |     "middleName" : "",
+             |     "familyName" : "Doe",
+             |     "birthdate" : "1980-01-10",
+             |     "address" : {
+             |       "line1" : "221b Baker St",
+             |       "line2" : "Marylebone",
+             |       "line3" : "",
+             |       "line4" : "",
+             |       "postCode" : "NW1 6XE",
+             |       "countryName" : "United Kingdom",
+             |       "countryCode" : "GB"
+             |     }
+             |  }
              |}
         """.stripMargin.replaceAll("\n", ""))))
     }


### PR DESCRIPTION
 - In the auth-login-api stubb / test session.
- For individuals only
 - Includes address + postCode