### PR TITLE
APSR-1355 - Remove address lines 3 & 4

### DIFF
--- a/app/uk/gov/hmrc/testuser/connectors/AuthLoginApiConnector.scala
+++ b/app/uk/gov/hmrc/testuser/connectors/AuthLoginApiConnector.scala
@@ -95,8 +95,6 @@ object ItmpData{
 case class AuthLoginAddress(
     line1: String,
     line2: String,
-    line3: String,
-    line4: String,
     postCode: String,
     countryName: String,
     countryCode: String)
@@ -106,8 +104,6 @@ object AuthLoginAddress {
     AuthLoginAddress(
       line1 = address.line1, 
       line2 = address.line2, 
-      line3 = "",
-      line4 = "", 
       postCode = address.postcode, 
       countryName = "United Kingdom",
       countryCode = "GB")

--- a/it/uk/gov/hmrc/testuser/connectors/AuthLoginApiConnectorSpec.scala
+++ b/it/uk/gov/hmrc/testuser/connectors/AuthLoginApiConnectorSpec.scala
@@ -206,8 +206,6 @@ class AuthLoginApiConnectorSpec extends AsyncHmrcSpec with GuiceOneAppPerSuite w
              |     "address" : {
              |       "line1" : "221b Baker St",
              |       "line2" : "Marylebone",
-             |       "line3" : "",
-             |       "line4" : "",
              |       "postCode" : "NW1 6XE",
              |       "countryName" : "United Kingdom",
              |       "countryCode" : "GB"


### PR DESCRIPTION
- From ITMP test data, as it was causing problem when the address was returned from the Userinfo API (with extra empty new lines).