### PR TITLE
APIS-5394 - Bug with organisation nino validation caused 500 error

### DIFF
--- a/app/uk/gov/hmrc/testuser/repository/TestUserRepository.scala
+++ b/app/uk/gov/hmrc/testuser/repository/TestUserRepository.scala
@@ -62,7 +62,7 @@ class TestUserRepository @Inject()(mongo: ReactiveMongoComponent)(implicit ec: E
   }
 
   def fetchByNino(nino: Nino): Future[Option[TestUser]] = {
-    find("nino" -> nino) map(_.headOption map (_.asInstanceOf[TestIndividual]))
+    find("nino" -> nino) map(_.headOption map (_.asInstanceOf[TestUser]))
   }
 
   def fetchIndividualByShortNino(shortNino: NinoNoSuffix): Future[Option[TestIndividual]] = {

--- a/it/uk/gov/hmrc/testuser/repository/TestUserRepositorySpec.scala
+++ b/it/uk/gov/hmrc/testuser/repository/TestUserRepositorySpec.scala
@@ -185,6 +185,15 @@ class TestUserRepositorySpec extends AsyncHmrcSpec with BeforeAndAfterEach with 
       result shouldBe Some(individual)
     }
 
+    "return the organisation" in new GeneratedTestOrganisation {
+      val organisation = testOrganisation.copy(nino = Some(nino.toString()))
+      await(repository.createUser(organisation))
+
+      val result = await(repository.fetchByNino(nino))
+
+      result shouldBe Some(organisation)
+    }
+
     "return None when there is no individual matching" in {
       val result = await(userRepository.fetchByNino(invalidNino))
 


### PR DESCRIPTION
 - Due to incorrect cast in repository