### PR TITLE
add emcs to create test user but using the eori identifier for now

### DIFF
--- a/app/uk/gov/hmrc/testuser/connectors/AuthLoginApiConnector.scala
+++ b/app/uk/gov/hmrc/testuser/connectors/AuthLoginApiConnector.scala
@@ -191,6 +191,7 @@ object GovernmentGatewayLogin {
         case CUSTOMS_SERVICES           => organisation.eoriNumber map { eoriNumber => Enrolment("HMRC-CUS-ORG", Seq(Identifier("EORINumber", eoriNumber))) }
         case CTC_LEGACY                 => organisation.eoriNumber map { eoriNumber => Enrolment("HMCE-NCTS-ORG", Seq(Identifier("VATRegNoTURN", eoriNumber))) }
         case CTC                        => organisation.eoriNumber map { eoriNumber => Enrolment("HMRC-CTC-ORG", Seq(Identifier("EORINumber", eoriNumber))) }
+        case EMCS                       => organisation.eoriNumber map { eoriNumber => Enrolment("HMRC-EMCS-ORG", Seq(Identifier("ExciseNumber", eoriNumber))) }
         case GOODS_VEHICLE_MOVEMENTS    => organisation.eoriNumber map { eoriNumber => Enrolment("HMRC-GVMS-ORG", Seq(Identifier("EORINumber", eoriNumber))) }
         case SAFETY_AND_SECURITY        => organisation.eoriNumber map { eoriNumber => Enrolment("HMRC-SS-ORG", Seq(Identifier("EORINumber", eoriNumber))) }
         case IMPORT_CONTROL_SYSTEM      => organisation.eoriNumber map { eoriNumber => Enrolment("HMRC-ICS-ORG", Seq(Identifier("EoriTin", eoriNumber))) }

--- a/app/uk/gov/hmrc/testuser/models/TestUser.scala
+++ b/app/uk/gov/hmrc/testuser/models/TestUser.scala
@@ -45,6 +45,7 @@ object ServiceKeys extends Enumeration {
   val SAFETY_AND_SECURITY: ServiceKeys.Value        = Value("safety-and-security")
   val CTC: ServiceKeys.Value                        = Value("common-transit-convention-traders")
   val CTC_LEGACY: ServiceKeys.Value                 = Value("common-transit-convention-traders-legacy")
+  val EMCS: ServiceKeys.Value                       = Value("excise-movement-control-system")
 }
 
 case class Service(key: ServiceKey, name: String, allowedUserTypes: Seq[UserType])
@@ -68,7 +69,8 @@ object Services extends Seq[Service] {
     Service(ServiceKeys.IMPORT_CONTROL_SYSTEM, "Import Control System", Seq(ORGANISATION)),
     Service(ServiceKeys.CTC_LEGACY, "Common Transit Convention Traders Legacy", Seq(INDIVIDUAL, ORGANISATION)),
     Service(ServiceKeys.CTC, "Common Transit Convention Traders", Seq(INDIVIDUAL, ORGANISATION)),
-    Service(ServiceKeys.SAFETY_AND_SECURITY, "Safety and Security", Seq(ORGANISATION))
+    Service(ServiceKeys.SAFETY_AND_SECURITY, "Safety and Security", Seq(ORGANISATION)),
+    Service(ServiceKeys.EMCS, "Excise Movement Control System", Seq(ORGANISATION))
   )
 
   override def length: Int = services.length
@@ -459,13 +461,15 @@ object PensionSchemeAdministratorIdentifier extends (String => PensionSchemeAdmi
 }
 
 case class EoriNumber(override val value: String) extends TaxIdentifier with SimpleName {
-  require(EoriNumber.isValid(value), s"$value is not a valid EORI.")
+  // Temporarily supports ExciseNumber for EMCS
+  require(EoriNumber.isValid(value), s"$value is not a valid EORI/ExciseNumber.")
 
   override val name = EoriNumber.name
 }
 
 object EoriNumber extends SimpleName {
-  val validEoriFormat = "^(GB|XI)[0-9]{12,15}$"
+  // Temporarily supports ExciseNumber for EMCS by adding | and the second capturing group
+  val validEoriFormat = "^((GB|XI)[0-9]{12,15})|([A-Z]{2}[a-zA-Z0-9]{11})$"
 
   def isValid(eoriNumber: String) = eoriNumber.matches(validEoriFormat)
 

--- a/it/uk/gov/hmrc/testuser/connectors/AuthLoginApiConnectorSpec.scala
+++ b/it/uk/gov/hmrc/testuser/connectors/AuthLoginApiConnectorSpec.scala
@@ -95,7 +95,8 @@ class AuthLoginApiConnectorSpec extends AsyncHmrcSpec with GuiceOneAppPerSuite w
       GOODS_VEHICLE_MOVEMENTS,
       SAFETY_AND_SECURITY,
       CTC_LEGACY,
-      CTC
+      CTC,
+      EMCS
     )
   )
 
@@ -407,6 +408,15 @@ class AuthLoginApiConnectorSpec extends AsyncHmrcSpec with GuiceOneAppPerSuite w
            |       "identifiers": [
            |       {
            |         "key":"EORINumber",
+           |         "value":"${testOrganisation.eoriNumber.get}"
+           |       }]
+           |     },
+           |     {
+           |       "key": "HMRC-EMCS-ORG",
+           |       "state": "Activated",
+           |       "identifiers": [
+           |       {
+           |         "key":"ExciseNumber",
            |         "value":"${testOrganisation.eoriNumber.get}"
            |       }]
            |     }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += "HMRC-open-artefacts-maven" at "https://open.artefacts.tax.service.gov.uk/maven2"
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc"          %  "sbt-auto-build"          % "3.13.0")
+addSbtPlugin("uk.gov.hmrc"          %  "sbt-auto-build"          % "3.14.0")
 addSbtPlugin("uk.gov.hmrc"          %  "sbt-distributables"      % "2.2.0")
 addSbtPlugin("com.typesafe.play"    %  "sbt-plugin"              % "2.8.18")
 addSbtPlugin("org.scoverage"        %  "sbt-scoverage"           % "1.9.3")

--- a/resources/public/api/conf/1.0/examples/create-organisation-request.json
+++ b/resources/public/api/conf/1.0/examples/create-organisation-request.json
@@ -15,7 +15,8 @@
     "import-control-system",
     "safety-and-security",
     "common-transit-convention-traders",
-    "common-transit-convention-traders-legacy"
+    "common-transit-convention-traders-legacy",
+    "excise-movement-control-system"
 ],
   "eoriNumber": "GB123456789012",
   "taxpayerType": "Individual"

--- a/resources/public/api/conf/1.0/schemas/create-organisation-request.json
+++ b/resources/public/api/conf/1.0/schemas/create-organisation-request.json
@@ -89,6 +89,11 @@
             "title": "common-transit-convention-traders-legacy",
             "enum": ["common-transit-convention-traders-legacy"],
             "description": "Generates an EORI number and enrols the user for legacy Common Transit Convention Traders."
+          },
+          {
+            "title": "excise-movement-control-system",
+            "enum": ["excise-movement-control-system"],
+            "description": "Generates an Excise Number and enrols the user for Excise Movement Control System."
           }
         ]
       },
@@ -96,10 +101,10 @@
     },
     "eoriNumber": {
       "type": "string",
-      "description": "Economic Operator Registration and Identification (EORI) number.",
-      "minLength": 14,
+      "description": "Economic Operator Registration and Identification (EORI) number. Also temporarily supports an Excise Number",
+      "minLength": 13,
       "maxLength": 17,
-      "pattern": "^(GB|XI)[0-9]{12,15}$"
+      "pattern": "^((GB|XI)[0-9]{12,15})|([A-Z]{2}[a-zA-Z0-9]{11})$"
     },
     "nino": {
       "type": "string",

--- a/test/uk/gov/hmrc/testuser/connectors/GovernmentGatewayLoginSpec.scala
+++ b/test/uk/gov/hmrc/testuser/connectors/GovernmentGatewayLoginSpec.scala
@@ -45,6 +45,7 @@ class GovernmentGatewayLoginSpec extends AsyncHmrcSpec {
   val secureElectronicTransferReferenceNumber = "123456789012"
   val pensionSchemeAdministratorIdentifier    = "A1234567"
   val eoriNumber                              = "GB1234567890"
+  val exciseNumber                            = "GBWK254706100"
   private val taxOfficeNumber                 = "555"
   private val taxOfficeReference              = "EIA000"
   val empRef                                  = s"$taxOfficeNumber/$taxOfficeReference"
@@ -65,6 +66,8 @@ class GovernmentGatewayLoginSpec extends AsyncHmrcSpec {
   val goodsVehicleMovementsEnrolment = Enrolment("HMRC-GVMS-ORG", Seq(Identifier("EORINumber", eoriNumber)))
   val ssEnrolment                    = Enrolment("HMRC-SS-ORG", Seq(Identifier("EORINumber", eoriNumber)))
   val icsEnrolment                   = Enrolment("HMRC-ICS-ORG", Seq(Identifier("EoriTin", eoriNumber)))
+  val emcsEnrolment                  = Enrolment("HMRC-EMCS-ORG", Seq(Identifier("ExciseNumber", exciseNumber)))
+  val emcsEnrolmentUsingDefaultEori  = Enrolment("HMRC-EMCS-ORG", Seq(Identifier("ExciseNumber", eoriNumber)))
 
   "A GovernmentGatewayLogin created from a TestAgent" should {
 
@@ -243,7 +246,8 @@ class GovernmentGatewayLoginSpec extends AsyncHmrcSpec {
         SAFETY_AND_SECURITY,
         CTC_LEGACY,
         CTC,
-        IMPORT_CONTROL_SYSTEM
+        IMPORT_CONTROL_SYSTEM,
+        EMCS
       )
     )
 
@@ -272,7 +276,8 @@ class GovernmentGatewayLoginSpec extends AsyncHmrcSpec {
           ssEnrolment,
           ctcEnrolment,
           ctcLegacyEnrolment,
-          icsEnrolment
+          icsEnrolment,
+          emcsEnrolmentUsingDefaultEori
         )
     }
 
@@ -324,6 +329,12 @@ class GovernmentGatewayLoginSpec extends AsyncHmrcSpec {
       val login = GovernmentGatewayLogin(organisation.copy(services = Seq(SAFETY_AND_SECURITY)))
 
       login.enrolments should contain theSameElementsAs Seq(ssEnrolment)
+    }
+
+    "contain the correct enrolment for excise movement control system" in {
+      val login = GovernmentGatewayLogin(organisation.copy(services = Seq(EMCS), eoriNumber = Some(exciseNumber)))
+
+      login.enrolments should contain theSameElementsAs Seq(emcsEnrolment)
     }
 
     "not have the credential role populated" in {

--- a/test/uk/gov/hmrc/testuser/controllers/TestUserControllerSpec.scala
+++ b/test/uk/gov/hmrc/testuser/controllers/TestUserControllerSpec.scala
@@ -64,6 +64,8 @@ class TestUserControllerSpec extends AsyncHmrcSpec with LogSuppressing {
   val pensionSchemeAdministratorIdentifier    = "A1234567"
   val rawEoriNumber                           = "GB123456789012"
   val eoriNumber                              = EoriNumber(rawEoriNumber)
+  val rawExciseNumber                         = "GBWK254706100"
+  val exciseNumber                            = EoriNumber(rawExciseNumber) // using EORI for now
   val taxpayerType                            = TaxpayerType("Individual")
   val rawTaxpayerType                         = "Individual"
 
@@ -152,6 +154,11 @@ class TestUserControllerSpec extends AsyncHmrcSpec with LogSuppressing {
 
     def createOrganisationWithProvidedEoriRequest = {
       val jsonPayload: JsValue = Json.parse(s"""{"serviceNames":["national-insurance"], "eoriNumber": "$rawEoriNumber"}""")
+      FakeRequest().withBody[JsValue](jsonPayload)
+    }
+
+    def createOrganisationWithProvidedExciseNumberRequest = {
+      val jsonPayload: JsValue = Json.parse(s"""{"serviceNames":["national-insurance"], "eoriNumber": "$rawExciseNumber"}""")
       FakeRequest().withBody[JsValue](jsonPayload)
     }
 
@@ -308,6 +315,20 @@ class TestUserControllerSpec extends AsyncHmrcSpec with LogSuppressing {
       )(any[HeaderCarrier])).thenReturn(successful(Right(testOrganisation)))
 
       val result = underTest.createOrganisation()(createOrganisationWithProvidedEoriRequest)
+
+      status(result) shouldBe CREATED
+    }
+
+    "return 201 (Created) with the created organisation with provided excise number" in new Setup {
+
+      when(underTest.testUserService.createTestOrganisation(
+        eqTo(createOrganisationServices),
+        eqTo(Some(exciseNumber)),
+        eqTo(None),
+        eqTo(None)
+      )(any[HeaderCarrier])).thenReturn(successful(Right(testOrganisation)))
+
+      val result = underTest.createOrganisation()(createOrganisationWithProvidedExciseNumberRequest)
 
       status(result) shouldBe CREATED
     }

--- a/test/uk/gov/hmrc/testuser/models/TestUserSpec.scala
+++ b/test/uk/gov/hmrc/testuser/models/TestUserSpec.scala
@@ -91,6 +91,6 @@ class TestUserSpec extends AnyFlatSpec with Matchers {
   }
 
   "Services" should "get size equal to all services when length called" in {
-    Services.length shouldBe 17
+    Services.length shouldBe 18
   }
 }


### PR DESCRIPTION
This adds the following service to the create test user api:
`excise-movement-control-system`
It also allows a test user to be created for the HMRC-EMCS-ORG enrolment as follows:
| Enrolment Key | Identifier Name | Identifier Value |
|--------|--------|--------|
| HMRC-EMCS-ORG | ExciseNumber | GBWK254706100 |

The design in [This JIRA ticket](https://jira.tools.tax.service.gov.uk/browse/APSR-1744) originally planned for a new identifier to be created in the create test user request and response but when doing the work, it was found that the number of fields in the TestOrganisation case class were already at the 22 limit for case classes. These changes therefore have made use of the existing EORI field but then map that to the EMCS enrolment. This is a tactical fix to allow us to get something out to Third Party Developers soon and the API platform team will be working on a strategic fix. Once the startegic fix is in place, we will revert the EORI back to how it was and use a new identifier for the excise number.