### PR TITLE
PIL-1821 & APSR-2002 - Updated regex for creation, pillar2 generation code and tests

### DIFF
--- a/app/uk/gov/hmrc/testuser/models/TestUser.scala
+++ b/app/uk/gov/hmrc/testuser/models/TestUser.scala
@@ -400,7 +400,7 @@ case class Pillar2Id(override val value: String) extends TaxIdentifier with Simp
 }
 
 object Pillar2Id extends SimpleName with (String => Pillar2Id) {
-  private val validPillar2IdFormat = "^[A-Z0-9]{15}$" // TODO: check with PM
+  private val validPillar2IdFormat = "^X[A-Z]{1}PLR[0-9]{10}$"
 
   def isValid(value: String) = value.matches(validPillar2IdFormat)
 

--- a/app/uk/gov/hmrc/testuser/services/Generator.scala
+++ b/app/uk/gov/hmrc/testuser/services/Generator.scala
@@ -406,9 +406,9 @@ class Pillar2IdGenerator(random: Random = new Random) {
 
   def next: String = {
     val randomLetter = ('A' to 'Z')(random.nextInt(26))
-    val randomDigits = (1 to 13).map(_ => random.nextInt(10)).mkString
+    val randomDigits = (1 to 10).map(_ => random.nextInt(10)).mkString
 
-    s"X$randomLetter$randomDigits"
+    s"X${randomLetter}PLR$randomDigits"
   }
 }
 

--- a/test/uk/gov/hmrc/testuser/controllers/TestUserControllerSpec.scala
+++ b/test/uk/gov/hmrc/testuser/controllers/TestUserControllerSpec.scala
@@ -50,7 +50,7 @@ class TestUserControllerSpec extends AsyncHmrcSpec with LogSuppressing {
   val ctUtr                                   = "1555369053"
   val crn                                     = "12345678"
   val vrn                                     = "999902541"
-  val pillar2Id                               = Pillar2Id("XE4444444444444")
+  val pillar2Id                               = Pillar2Id("XEPLR4444444444")
   val vatRegistrationDate                     = LocalDate.parse("2011-07-07")
   private val taxOfficeNum                    = "555"
   private val taxOfficeRef                    = "EIA000"

--- a/test/uk/gov/hmrc/testuser/models/TestUserSpec.scala
+++ b/test/uk/gov/hmrc/testuser/models/TestUserSpec.scala
@@ -77,11 +77,13 @@ class TestUserSpec extends AnyFlatSpec with Matchers {
   }
 
   "Pillar 2 ID" should "validate" in {
-    Pillar2Id.isValid("XE1261614875876") shouldBe true
+    Pillar2Id.isValid("XEPLR1261614875") shouldBe true
 
     Pillar2Id.isValid("1234567890123") shouldBe false
     Pillar2Id.isValid("XE12345678901234") shouldBe false
     Pillar2Id.isValid("XEABCDEFGHIJK") shouldBe false
+    Pillar2Id.isValid("XEPLR123456789012") shouldBe false
+    Pillar2Id.isValid("DUXEPLR1234567890") shouldBe false
   }
 
   "TestOrganisationCreatedResponse" should "be properly constructed from a TestOrganisation" in {

--- a/test/uk/gov/hmrc/testuser/services/GeneratorSpec.scala
+++ b/test/uk/gov/hmrc/testuser/services/GeneratorSpec.scala
@@ -81,7 +81,10 @@ trait GeneratorProvider {
 
   val ninoGenerator = Gen.listOfN(6, Gen.numChar).map("PE" + _.mkString + "A")
 
-  val pillar2IdGenerator = Gen.stringOfN(13, Gen.numChar).map("XE" + _.mkString).map(Pillar2Id.apply)
+  val pillar2IdGenerator = for {
+    randomLetter <- Gen.alphaUpperChar
+    randomDigits <- Gen.listOfN(10, Gen.numChar)
+  } yield Pillar2Id(s"X${randomLetter}PLR${randomDigits.mkString}")
 }
 
 class GeneratorSpec extends AsyncHmrcSpec with ScalaCheckPropertyChecks {

--- a/test/uk/gov/hmrc/testuser/services/TestUserServiceSpec.scala
+++ b/test/uk/gov/hmrc/testuser/services/TestUserServiceSpec.scala
@@ -235,7 +235,7 @@ class TestUserServiceSpec extends AsyncHmrcSpec {
     }
 
     "fail when the pillar2Id validation fails" in new Setup {
-      val pillar2Id = Pillar2Id("XE4444444444444")
+      val pillar2Id = Pillar2Id("XEPLR4444444444")
       when(underTest.testUserRepository.fetchOrganisationByPillar2Id(eqTo(pillar2Id)))
         .thenReturn(Future.successful(Some(testOrganisation)))
 


### PR DESCRIPTION
External Orgs can create a Test Org for a given Service with this API. They can either provide the API with the service name "pillar-2" and it will generate a new user with a random pillar 2 ID that should conform to a valid Pillar 2 ID format or they can provide the service name and an ID of their choosing which also should match a valid Pillar 2 ID format. It is currently incorrect and this PR is to correct it.

### Changes
* The regex used to validate a provided Pillar 2 ID by an external party
* The generator that creates a random Pillar 2 ID
* Corresponding tests